### PR TITLE
Create and configure rabbit user before the Abiquo server starts

### DIFF
--- a/recipes/install_ext_services.rb
+++ b/recipes/install_ext_services.rb
@@ -47,18 +47,19 @@ end
 execute "create-abiquo-rabbit-user" do
     command "rabbitmqctl add_user #{node['abiquo']['properties']['abiquo.rabbitmq.username']} #{node['abiquo']['properties']['abiquo.rabbitmq.username']}"
     action :nothing
-    subscribes :run, "service[rabbitmq-server]", :immediately
+    subscribes :run, "service[rabbitmq-server]"
     not_if "rabbitmqctl list_users | egrep -q '^#{node['abiquo']['properties']['abiquo.rabbitmq.username']}.*'"
 end
 
 execute "set-abiquo-rabbit-user-administrator" do
     command "rabbitmqctl set_user_tags #{node['abiquo']['properties']['abiquo.rabbitmq.username']} administrator"
     action :nothing
-    subscribes :run, "execute[create-abiquo-rabbit-user]", :immediately
+    subscribes :run, "execute[create-abiquo-rabbit-user]"
 end
 
 execute "set-abiquo-rabbit-user-permissions" do
     command "rabbitmqctl set_permissions -p / #{node['abiquo']['properties']['abiquo.rabbitmq.username']} '.*' '.*' '.*'"
     action :nothing
-    subscribes :run, "execute[create-abiquo-rabbit-user]", :immediately
+    subscribes :run, "execute[create-abiquo-rabbit-user]"
+    notifies :restart, "service[abiquo-tomcat]"
 end

--- a/recipes/install_ext_services.rb
+++ b/recipes/install_ext_services.rb
@@ -47,18 +47,18 @@ end
 execute "create-abiquo-rabbit-user" do
     command "rabbitmqctl add_user #{node['abiquo']['properties']['abiquo.rabbitmq.username']} #{node['abiquo']['properties']['abiquo.rabbitmq.username']}"
     action :nothing
-    subscribes :run, "service[rabbitmq-server]"
+    subscribes :run, "service[rabbitmq-server]", :immediately
     not_if "rabbitmqctl list_users | egrep -q '^#{node['abiquo']['properties']['abiquo.rabbitmq.username']}.*'"
 end
 
 execute "set-abiquo-rabbit-user-administrator" do
     command "rabbitmqctl set_user_tags #{node['abiquo']['properties']['abiquo.rabbitmq.username']} administrator"
     action :nothing
-    subscribes :run, "execute[create-abiquo-rabbit-user]"
+    subscribes :run, "execute[create-abiquo-rabbit-user]", :immediately
 end
 
 execute "set-abiquo-rabbit-user-permissions" do
     command "rabbitmqctl set_permissions -p / #{node['abiquo']['properties']['abiquo.rabbitmq.username']} '.*' '.*' '.*'"
     action :nothing
-    subscribes :run, "execute[create-abiquo-rabbit-user]"
+    subscribes :run, "execute[create-abiquo-rabbit-user]", :immediately
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -20,7 +20,7 @@ describe 'abiquo::default' do
         ChefSpec::SoloRunner.new(file_cache_path: '/tmp') do |node|
             node.set['cassandra']['config']['cluster_name'] = 'abiquo'
             node.set['abiquo']['certificate']['common_name'] = 'test.local'
-        end.converge(described_recipe)
+        end
     end
     let(:cn) { 'test.local' }
     
@@ -32,14 +32,14 @@ describe 'abiquo::default' do
     end
 
     it 'changes selinux to permissive' do
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to permissive_selinux_state("SELinux Permissive")
     end
 
     %w{monolithic server v2v remoteservices kvm monitoring}.each do |profile|
         it "includes the recipes for the #{profile} profile" do
             chef_run.node.set['abiquo']['profile'] = profile
-            chef_run.converge(described_recipe)
+            chef_run.converge(described_recipe, 'abiquo::service')
             expect(chef_run).to include_recipe('abiquo::repository')
             expect(chef_run).to include_recipe("abiquo::install_#{profile}")
             expect(chef_run).to include_recipe("abiquo::setup_#{profile}")
@@ -47,7 +47,7 @@ describe 'abiquo::default' do
 
         it "configures the #{profile} firewall" do
             chef_run.node.set['abiquo']['profile'] = profile
-            chef_run.converge(described_recipe)
+            chef_run.converge(described_recipe, 'abiquo::service')
             expect(chef_run).to include_recipe('iptables')
             expect(chef_run).to enable_iptables_rule('firewall-common')
             expect(chef_run).to enable_iptables_rule("firewall-#{profile}")

--- a/spec/install_ext_services_spec.rb
+++ b/spec/install_ext_services_spec.rb
@@ -22,14 +22,14 @@ describe 'abiquo::install_ext_services' do
     end
 
     it 'uninstalls mysql-libs package' do
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to purge_package('mysql-libs')
     end
 
     %w{monolithic server}.each do |profile|
         it "installs the #{profile} system packages" do
             chef_run.node.set['abiquo']['profile'] = profile
-            chef_run.converge(described_recipe)
+            chef_run.converge(described_recipe, 'abiquo::service')
             %w{MariaDB-server MariaDB-client redis rabbitmq-server}.each do |pkg|
                 expect(chef_run).to install_package(pkg)
             end
@@ -37,7 +37,7 @@ describe 'abiquo::install_ext_services' do
         
         it "configures the #{profile} services" do
             chef_run.node.set['abiquo']['profile'] = profile
-            chef_run.converge(described_recipe)
+            chef_run.converge(described_recipe, 'abiquo::service')
             %w{mysql rabbitmq-server redis}.each do |svc|
                 expect(chef_run).to enable_service(svc)
                 expect(chef_run).to start_service(svc)
@@ -47,20 +47,20 @@ describe 'abiquo::install_ext_services' do
         
     it "installs the remoteservices system packages" do
         chef_run.node.set['abiquo']['profile'] = "remoteservices"
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to install_package("redis")
     end
  
     it "configures the remoteservices services" do
         chef_run.node.set['abiquo']['profile'] = "remoteservices"
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to enable_service("redis")
         expect(chef_run).to start_service("redis")
     end
     
     it "installs the monitoring system packages" do
         chef_run.node.set['abiquo']['profile'] = "monitoring"
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         %w{MariaDB-server MariaDB-client}.each do |pkg|
             expect(chef_run).to install_package(pkg)
         end
@@ -68,27 +68,28 @@ describe 'abiquo::install_ext_services' do
 
     it "configures the monitoring services" do
         chef_run.node.set['abiquo']['profile'] = "monitoring"
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to enable_service("mysql")
         expect(chef_run).to start_service("mysql")
     end
 
     it "creates a rabbit user for Abiquo" do
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
 
         resource = chef_run.find_resource(:execute, 'create-abiquo-rabbit-user')
         expect(resource).to do_nothing
         expect(resource.command).to eq('rabbitmqctl add_user abiquo abiquo')
-        expect(resource).to subscribe_to('service[rabbitmq-server]').on(:run).immediately
+        expect(resource).to subscribe_to('service[rabbitmq-server]').on(:run).delayed
 
         resource = chef_run.find_resource(:execute, 'set-abiquo-rabbit-user-administrator')
         expect(resource).to do_nothing
         expect(resource.command).to eq('rabbitmqctl set_user_tags abiquo administrator')
-        expect(resource).to subscribe_to('execute[create-abiquo-rabbit-user]').on(:run).immediately
+        expect(resource).to subscribe_to('execute[create-abiquo-rabbit-user]').on(:run).delayed
 
         resource = chef_run.find_resource(:execute, 'set-abiquo-rabbit-user-permissions')
         expect(resource).to do_nothing
         expect(resource.command).to eq("rabbitmqctl set_permissions -p / abiquo '.*' '.*' '.*'")
-        expect(resource).to subscribe_to('execute[create-abiquo-rabbit-user]').on(:run).immediately
+        expect(resource).to subscribe_to('execute[create-abiquo-rabbit-user]').on(:run).delayed
+        expect(resource).to notify('service[abiquo-tomcat]').to(:restart).delayed
     end
 end

--- a/spec/install_ext_services_spec.rb
+++ b/spec/install_ext_services_spec.rb
@@ -79,16 +79,16 @@ describe 'abiquo::install_ext_services' do
         resource = chef_run.find_resource(:execute, 'create-abiquo-rabbit-user')
         expect(resource).to do_nothing
         expect(resource.command).to eq('rabbitmqctl add_user abiquo abiquo')
-        expect(resource).to subscribe_to('service[rabbitmq-server]').on(:run).delayed
+        expect(resource).to subscribe_to('service[rabbitmq-server]').on(:run).immediately
 
         resource = chef_run.find_resource(:execute, 'set-abiquo-rabbit-user-administrator')
         expect(resource).to do_nothing
         expect(resource.command).to eq('rabbitmqctl set_user_tags abiquo administrator')
-        expect(resource).to subscribe_to('execute[create-abiquo-rabbit-user]').on(:run).delayed
+        expect(resource).to subscribe_to('execute[create-abiquo-rabbit-user]').on(:run).immediately
 
         resource = chef_run.find_resource(:execute, 'set-abiquo-rabbit-user-permissions')
         expect(resource).to do_nothing
         expect(resource.command).to eq("rabbitmqctl set_permissions -p / abiquo '.*' '.*' '.*'")
-        expect(resource).to subscribe_to('execute[create-abiquo-rabbit-user]').on(:run).delayed
+        expect(resource).to subscribe_to('execute[create-abiquo-rabbit-user]').on(:run).immediately
     end
 end

--- a/spec/install_monitoring_spec.rb
+++ b/spec/install_monitoring_spec.rb
@@ -18,7 +18,7 @@ describe 'abiquo::install_monitoring' do
     let(:chef_run) do
         ChefSpec::SoloRunner.new(file_cache_path: '/tmp') do |node|
             node.set['abiquo']['profile'] = 'monitoring'
-        end.converge(described_recipe)
+        end
     end
     let(:pkg) { "kairosdb-#{chef_run.node['abiquo']['monitoring']['kairosdb']['version']}-#{chef_run.node['abiquo']['monitoring']['kairosdb']['release']}.rpm" }
     let(:url) { "https://github.com/kairosdb/kairosdb/releases/download/v#{chef_run.node['abiquo']['monitoring']['kairosdb']['version']}/#{pkg}" }
@@ -28,26 +28,26 @@ describe 'abiquo::install_monitoring' do
     end
 
     it 'downloads the kairosdb package' do
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to create_remote_file("#{Chef::Config[:file_cache_path]}/#{pkg}").with({
             :source => url
         })
     end
 
     it 'installs the kairosdb package' do
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to install_package('kairosdb').with({
             :source => "#{Chef::Config[:file_cache_path]}/#{pkg}"
         })
     end
 
     it 'installs the jdk package' do
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to install_package('jdk')
     end
 
     it 'configures the java alternatives' do
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to set_java_alternatives('set default jdk8').with({
             :java_location => '/usr/java/default',
             :bin_cmds => ['java', 'javac']
@@ -55,30 +55,30 @@ describe 'abiquo::install_monitoring' do
     end
 
     it 'includes the cassandra recipe' do
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to include_recipe('cassandra-dse')
     end
 
     it 'includes the install_ext_services recipe by default' do
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to include_recipe('abiquo::install_ext_services')
     end
 
     it 'does not include install_ext_services recipe if not configured' do
         chef_run.node.set['abiquo']['install_ext_services'] = false
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to_not include_recipe('abiquo::install_ext_services')
     end
 
     %w{delorean emmett}.each do |pkg|
         it "installs the abiquo-#{pkg} package" do
-            chef_run.converge(described_recipe)
+            chef_run.converge(described_recipe, 'abiquo::service')
             expect(chef_run).to install_package("abiquo-#{pkg}")
         end
     end
 
     it 'installs the database by default' do
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to run_execute('create-watchtower-database').with(
             :command => '/usr/bin/mysql -h localhost -P 3306 -u root -e \'CREATE SCHEMA watchtower\''
         )
@@ -89,7 +89,7 @@ describe 'abiquo::install_monitoring' do
 
     it 'does not install the database if not configured' do
         chef_run.node.set['abiquo']['monitoring']['db']['install'] = false
-        chef_run.converge(described_recipe)
+        chef_run.converge(described_recipe, 'abiquo::service')
         expect(chef_run).to_not run_execute('install-watchtower-database')
     end
 end

--- a/spec/install_remoteservices_spec.rb
+++ b/spec/install_remoteservices_spec.rb
@@ -15,7 +15,7 @@
 require 'spec_helper'
 
 describe 'abiquo::install_remoteservices' do
-    let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+    let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe, 'abiquo::service') }
 
     before do
         stub_command("rabbitmqctl list_users | egrep -q '^abiquo.*'").and_return(false)

--- a/spec/install_v2v_spec.rb
+++ b/spec/install_v2v_spec.rb
@@ -15,7 +15,7 @@
 require 'spec_helper'
 
 describe 'abiquo::install_v2v' do
-    let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+    let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe, 'abiquo::service') }
 
     it "installs the jdk package" do
         expect(chef_run).to install_package("jdk")


### PR DESCRIPTION
This is needed if the rabbit user does not yet exist, as by default the creation of the user is delayed *after* the tomcat server is started, and the apps fail to connect to Rabbit, as the properties are already configured with the new rabbit user.

/cc @chirauki 