### PR TITLE
Fix watchtower setup:

### DIFF
--- a/recipes/install_ext_services.rb
+++ b/recipes/install_ext_services.rb
@@ -30,6 +30,9 @@ when "remoteservices"
 when "monitoring"
     packages = %w{MariaDB-server MariaDB-client}
     services = %w{mysql}
+else
+    packages = []
+    services = []
 end
 
 packages.each do |pkg|

--- a/recipes/upgrade.rb
+++ b/recipes/upgrade.rb
@@ -68,7 +68,7 @@ end
 
 execute "watchtower-liquibase-update" do
   only_if { node['abiquo']['profile'] == 'monitoring' }
-  command "/usr/bin/abiquo-watchtower-liquibase update"
+  command "abiquo-watchtower-liquibase update"
   subscribes :run, "package[abiquo-delorean]", :immediately
   notifies :restart, "service[abiquo-delorean]" if node['abiquo']['profile'] == 'monitoring'
   action :nothing

--- a/recipes/upgrade.rb
+++ b/recipes/upgrade.rb
@@ -66,4 +66,10 @@ execute "liquibase-update" do
     notifies :restart, "service[abiquo-tomcat]" if node['abiquo']['profile'] == 'monolithic' || node['abiquo']['profile'] == 'server'
 end
 
+execute "watchtower-liquibase-update" do
+  only_if { node['abiquo']['profile'] == 'monitoring' }
+  command "/usr/bin/abiquo-watchtower-liquibase update"
+  action :nothing
+end
+
 include_recipe "abiquo::setup_#{node['abiquo']['profile']}"

--- a/recipes/upgrade.rb
+++ b/recipes/upgrade.rb
@@ -69,6 +69,8 @@ end
 execute "watchtower-liquibase-update" do
   only_if { node['abiquo']['profile'] == 'monitoring' }
   command "/usr/bin/abiquo-watchtower-liquibase update"
+  subscribes :run, "package[abiquo-delorean]", :immediately
+  notifies :restart, "service[abiquo-delorean]" if node['abiquo']['profile'] == 'monitoring'
   action :nothing
 end
 

--- a/spec/install_monitoring_spec.rb
+++ b/spec/install_monitoring_spec.rb
@@ -86,7 +86,10 @@ describe 'abiquo::install_monitoring' do
             :command => '/usr/bin/mysql -h localhost -P 3306 -u root -ppass -e \'CREATE SCHEMA watchtower\''
         )
         expect(chef_run).to run_execute('install-watchtower-database').with(
-            :command => '/usr/bin/mysql -h localhost -P 3306 -u root -ppass watchtower < /usr/share/doc/abiquo-watchtower/database/watchtower_schema.sql'
+            :command => '/usr/bin/mysql -h localhost -P 3306 -u root -ppass watchtower < /usr/share/doc/abiquo-watchtower/database/src/watchtower-1.0.0.sql'
+        )
+        expect(chef_run).to run_execute('run-watchtower-liquibase').with(
+            :command => '/usr/bin/abiquo-watchtower-liquibase update'
         )
     end
 


### PR DESCRIPTION
- Current logic does not import the schema into watchtower DB
- The schema in not the release final schema and hence
  abiquo-watchtower-liquibase is reuqired even for non upgrades
- Add specs