### PR TITLE
Add tests for RHEL

### DIFF
--- a/.kitchen.rhel.yml
+++ b/.kitchen.rhel.yml
@@ -1,0 +1,168 @@
+driver:
+  name: vagrant
+  customize:
+    memory: 2048
+
+provisioner:
+  name: chef_zero
+  require_chef_omnibus: 12.5.1
+  data_path: test/fixtures
+
+transport:
+  compression: none
+
+platforms:
+  - name: rhel-6.8
+
+suites:
+  - name: monolithic
+    run_list:
+      - recipe[rhn_register::register]
+      - recipe[abiquo::default]
+      - recipe[abiquo::upgrade]
+      - recipe[rhn_register::unregister]
+    attributes:
+      rhn_register:
+        username: <%= ENV['RHN_USERNAME'] %>
+        password: <%= ENV['RHN_PASSWORD'] %>
+      abiquo:
+        ui_config:
+          config.endpoint: "https://monolithic.abiquo.com/api"
+        ui_apache_opts:
+          KeepAlive: "On"
+          MaxKeepAliveRequests: 100
+          KeepAliveTimeout: 60
+        ui_proxies:
+          /am2: http://some_am:8009/am
+        certificate:
+          common_name: monolithic.abiquo.com
+  - name: server
+    run_list:
+      - recipe[rhn_register::register]
+      - recipe[abiquo::default]
+      - recipe[abiquo::upgrade]
+      - recipe[rhn_register::unregister]
+    attributes:
+      rhn_register:
+        username: <%= ENV['RHN_USERNAME'] %>
+        password: <%= ENV['RHN_PASSWORD'] %>
+      abiquo:
+        profile: server
+        ui_config:
+          config.endpoint: "https://server.abiquo.com/api"
+          client.backto.url: "http://google.com"
+          client.google.maps.key: "trocotro"
+          client.test.timeout: 600
+        ui_apache_opts:
+          KeepAlive: "On"
+          MaxKeepAliveRequests: 100
+          KeepAliveTimeout: 60
+        ui_proxies:
+          /am2: http://some_am:8009/am
+        certificate:
+          common_name: server.abiquo.com
+  - name: frontend
+    run_list:
+      - recipe[rhn_register::register]
+      - recipe[abiquo::default]
+      - recipe[abiquo::upgrade]
+      - recipe[rhn_register::unregister]
+    attributes:
+      rhn_register:
+        username: <%= ENV['RHN_USERNAME'] %>
+        password: <%= ENV['RHN_PASSWORD'] %>
+      abiquo:
+        profile: frontend
+        ui_config:
+          config.endpoint: "https://server.abiquo.com/api"
+          client.backto.url: "http://google.com"
+          client.google.maps.key: "trocotro"
+          client.test.timeout: 600
+        certificate:
+          common_name: frontend.abiquo.com
+  - name: ui
+    run_list:
+      - recipe[rhn_register::register]
+      - recipe[abiquo::default]
+      - recipe[abiquo::upgrade]
+      - recipe[rhn_register::unregister]
+    attributes:
+      rhn_register:
+        username: <%= ENV['RHN_USERNAME'] %>
+        password: <%= ENV['RHN_PASSWORD'] %>
+      abiquo:
+        profile: ui
+        ui_config:
+          config.endpoint: "https://server.abiquo.com/api"
+          client.backto.url: "http://google.com"
+          client.google.maps.key: "trocotro"
+          client.test.timeout: 600
+        certificate:
+          common_name: server.abiquo.com
+  - name: websockify
+    run_list:
+      - recipe[rhn_register::register]
+      - recipe[abiquo::default]
+      - recipe[abiquo::upgrade]
+      - recipe[rhn_register::unregister]
+    attributes:
+      rhn_register:
+        username: <%= ENV['RHN_USERNAME'] %>
+        password: <%= ENV['RHN_PASSWORD'] %>
+      abiquo:
+        profile: websockify
+        certificate:
+          common_name: ws.abiquo.com
+  - name: remoteservices
+    run_list:
+      - recipe[rhn_register::register]
+      - recipe[abiquo::default]
+      - recipe[abiquo::upgrade]
+      - recipe[rhn_register::unregister]
+    attributes:
+      rhn_register:
+        username: <%= ENV['RHN_USERNAME'] %>
+        password: <%= ENV['RHN_PASSWORD'] %>
+      abiquo:
+        profile: remoteservices
+  - name: v2v
+    run_list:
+      - recipe[rhn_register::register]
+      - recipe[abiquo::default]
+      - recipe[abiquo::upgrade]
+      - recipe[rhn_register::unregister]
+    attributes:
+      rhn_register:
+        username: <%= ENV['RHN_USERNAME'] %>
+        password: <%= ENV['RHN_PASSWORD'] %>
+      abiquo:
+        profile: v2v
+  - name: kvm
+    run_list:
+      - recipe[rhn_register::register]
+      - recipe[abiquo::default]
+      - recipe[abiquo::upgrade]
+      - recipe[rhn_register::unregister]
+    attributes:
+      rhn_register:
+        username: <%= ENV['RHN_USERNAME'] %>
+        password: <%= ENV['RHN_PASSWORD'] %>
+      abiquo:
+        profile: kvm
+  - name: monitoring
+    run_list:
+      # The Delorean service needs a running RabbitMQ instance
+      - recipe[rhn_register::register]
+      - recipe[abiquo::repository]
+      - recipe[rabbitmq]
+      - recipe[abiquo::default]
+      - recipe[abiquo::upgrade]
+      - recipe[rhn_register::unregister]
+    attributes:
+      rhn_register:
+        username: <%= ENV['RHN_USERNAME'] %>
+        password: <%= ENV['RHN_PASSWORD'] %>
+      abiquo:
+        profile: monitoring
+      rabbitmq:
+        version: 3.5.4

--- a/Berksfile
+++ b/Berksfile
@@ -8,3 +8,7 @@ cookbook 'compat_resource', '~> 12.10.6'
 # Used to install RabbitMQ when testing the monitoring
 # recipe with kitchen.
 cookbook 'rabbitmq', '= 4.6.0', group: 'test'
+
+# Used to register a node in RHN and unregister
+# after run for kitchen tests.
+cookbook 'rhn_register', path: 'test/fixtures/cookbooks/rhn_register', group: 'test'

--- a/README.md
+++ b/README.md
@@ -202,6 +202,16 @@ Once installed you can run the unit and integration tests as follows:
 The tests and Gemfile have been developed using Ruby 2.1.5, and that is the recommended Ruby version to use to run the tests.
 Other versions may cause conflicts with the versions of the gems Bundler will install.
 
+## RHEL testing
+
+Integration tests for RHEL are specified in a separate ```.kitchen.rhel.yml``` file. They use a vagrant box named ```rhel-6.8``` which you will need to build and add to the host running the tests as described in [bento project repository](https://github.com/chef/bento).
+
+Once the box is available in the host, you can run the tests by specifying the kitchen config file to use and the user and password so the VM can register to RedHat and get a subscription.
+
+```
+$ KITCHEN_LOCAL_YAML=.kitchen.rhel.yml RHN_USERNAME=some_user RHN_PASSWORD=some_pass bundle exec rake kitchen-basic
+```
+
 # License and Authors
 
 * Author:: Ignasi Barrera (ignasi.barrera@abiquo.com)

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,8 @@ desc 'Run Test Kitchen basic integration tests'
 task 'kitchen-basic' do
     require 'kitchen'
     Kitchen.logger = Kitchen.default_file_logger
-    config = Kitchen::Config.new
+    @loader = Kitchen::Loader::YAML.new(local_config: ENV['KITCHEN_LOCAL_YAML'])
+    config = Kitchen::Config.new(loader: @loader)
     config.instances.select { |i| i.name =~ /monolithic/ || i.name =~ /monitoring/ }.each do |instance|
         instance.test(:always)
     end
@@ -25,7 +26,8 @@ desc 'Run Test Kitchen integration tests'
 task :kitchen do
     require 'kitchen'
     Kitchen.logger = Kitchen.default_file_logger
-    Kitchen::Config.new.instances.each do |instance|
+    @loader = Kitchen::Loader::YAML.new(local_config: ENV['KITCHEN_LOCAL_YAML'])
+    Kitchen::Config.new(loader: @loader).instances.each do |instance|
         instance.test(:always)
     end
 end

--- a/test/fixtures/cookbooks/rhn_register/README.md
+++ b/test/fixtures/cookbooks/rhn_register/README.md
@@ -1,0 +1,1 @@
+# rhn_register cookbook

--- a/test/fixtures/cookbooks/rhn_register/attributes/default.rb
+++ b/test/fixtures/cookbooks/rhn_register/attributes/default.rb
@@ -1,2 +1,19 @@
+# Cookbook Name:: rhn_register
+# Attributes:: rhn_register
+#
+# Copyright 2014, Abiquo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 default['rhn_register']['username'] = 'user'
 default['rhn_register']['password'] = 'pass'

--- a/test/fixtures/cookbooks/rhn_register/attributes/default.rb
+++ b/test/fixtures/cookbooks/rhn_register/attributes/default.rb
@@ -1,0 +1,2 @@
+default['rhn_register']['username'] = 'user'
+default['rhn_register']['password'] = 'pass'

--- a/test/fixtures/cookbooks/rhn_register/metadata.rb
+++ b/test/fixtures/cookbooks/rhn_register/metadata.rb
@@ -1,0 +1,14 @@
+name             'rhn_register'
+maintainer       'Abiquo'
+maintainer_email 'marc.cirauqui@abiquo.com'
+license          'Apache 2.0'
+description      'Registers and unregisters a node from RHN'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.0.1'
+
+recipe 'rhn_register::register', 'Installs and configures an Abiquo platform'
+recipe 'rhn_register::unregister', 'Installs and configures an Abiquo platform'
+
+supports 'redhat', '>= 6.7'
+
+depends 'redhat_subscription_manager', '~> 0.5.0'

--- a/test/fixtures/cookbooks/rhn_register/recipes/register.rb
+++ b/test/fixtures/cookbooks/rhn_register/recipes/register.rb
@@ -1,3 +1,20 @@
+# Cookbook Name:: rhn_register
+# Recipe:: register
+#
+# Copyright 2014, Abiquo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 rhsm_register node['fqdn'] do
   username node['rhn_register']['username']
   password node['rhn_register']['password']

--- a/test/fixtures/cookbooks/rhn_register/recipes/register.rb
+++ b/test/fixtures/cookbooks/rhn_register/recipes/register.rb
@@ -1,0 +1,7 @@
+rhsm_register node['fqdn'] do
+  username node['rhn_register']['username']
+  password node['rhn_register']['password']
+  install_katello_agent false
+  auto_attach true
+  action :register
+end

--- a/test/fixtures/cookbooks/rhn_register/recipes/unregister.rb
+++ b/test/fixtures/cookbooks/rhn_register/recipes/unregister.rb
@@ -1,0 +1,5 @@
+rhsm_register node['fqdn'] do
+  username node['rhn_register']['username']
+  password node['rhn_register']['password']
+  action :unregister
+end

--- a/test/fixtures/cookbooks/rhn_register/recipes/unregister.rb
+++ b/test/fixtures/cookbooks/rhn_register/recipes/unregister.rb
@@ -1,3 +1,20 @@
+# Cookbook Name:: rhn_register
+# Recipe:: unregister
+#
+# Copyright 2014, Abiquo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 rhsm_register node['fqdn'] do
   username node['rhn_register']['username']
   password node['rhn_register']['password']


### PR DESCRIPTION
- Adds a new test cookbook to manage the registration and de-registration
before and after each chef run.
- Splits RHEL kitchen.yml file.
- Adds info on RHEL testing to README.