### PR TITLE
Change attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -95,6 +95,8 @@ default['abiquo']['monitoring']['db']['user'] = 'root'
 default['abiquo']['monitoring']['db']['password'] = ''
 default['abiquo']['monitoring']['db']['install'] = true
 default['abiquo']['monitoring']['emmett']['port'] = 36638
+default['abiquo']['monitoring']['kairosdb_package'] = "kairosdb-#{node['abiquo']['monitoring']['kairosdb']['version']}-#{node['abiquo']['monitoring']['kairosdb']['release']}.rpm"
+default['abiquo']['monitoring']['kairosdb_url'] = "https://github.com/kairosdb/kairosdb/releases/download/v#{node['abiquo']['monitoring']['kairosdb']['version']}/#{node['abiquo']['monitoring']['kairosdb_package']}"
 
 # Override the Apache proxy configuration
 override['apache']['proxy']['order'] = "allow,deny"
@@ -116,8 +118,8 @@ default['abiquo']['properties']['abiquo.rabbitmq.username'] = 'abiquo'
 default['abiquo']['properties']['abiquo.rabbitmq.password'] = 'abiquo'
 default['abiquo']['properties']['abiquo.rabbitmq.host'] = '127.0.0.1'
 default['abiquo']['properties']['abiquo.rabbitmq.port'] = 5672
-default['abiquo']['properties']['abiquo.vncport.min'] = 6000
-default['abiquo']['properties']['abiquo.vncport.max'] = 6999
+default['abiquo']['properties']['abiquo.vncport.min'] = 5900
+default['abiquo']['properties']['abiquo.vncport.max'] = 5999
 
 case node['abiquo']['profile']
 when "monolithic", "server"

--- a/recipes/install_monitoring.rb
+++ b/recipes/install_monitoring.rb
@@ -17,15 +17,12 @@
 
 Chef::Recipe.send(:include, Abiquo::Commands)
 
-kairosdb_package = "kairosdb-#{node['abiquo']['monitoring']['kairosdb']['version']}-#{node['abiquo']['monitoring']['kairosdb']['release']}.rpm"
-kairosdb_url = "https://github.com/kairosdb/kairosdb/releases/download/v#{node['abiquo']['monitoring']['kairosdb']['version']}/#{kairosdb_package}"
-
-remote_file "#{Chef::Config[:file_cache_path]}/#{kairosdb_package}" do
-    source kairosdb_url
+remote_file "#{Chef::Config[:file_cache_path]}/#{node['abiquo']['monitoring']['kairosdb_package']}" do
+    source node['abiquo']['monitoring']['kairosdb_url']
 end
 
 package "kairosdb" do
-    source "#{Chef::Config[:file_cache_path]}/#{kairosdb_package}"
+    source "#{Chef::Config[:file_cache_path]}/#{node['abiquo']['monitoring']['kairosdb_package']}"
 end
 
 package "jdk" do


### PR DESCRIPTION
- Set default VNC port start to the same as Abiquo properties default
- Move the KairosDB package URL to recipe attributes