### PR TITLE
Fix UI proxy config

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,9 +49,9 @@ default['abiquo']['tomcat']['ajp-port'] = 8010
 default['abiquo']['tomcat']['wait-for-webapps'] = false
 
 # Override the Apache proxy configuration
-override['apache']['proxy']['order'] = "allow,deny"
-override['apache']['proxy']['deny_from']  = "none"
-override['apache']['proxy']['allow_from'] = "all"
+default['apache']['proxy']['order'] = "allow,deny"
+default['apache']['proxy']['deny_from']  = "none"
+default['apache']['proxy']['allow_from'] = "all"
 
 # UI Apache configuration
 default['abiquo']['ui_apache_opts'] = {}
@@ -99,12 +99,12 @@ default['abiquo']['monitoring']['kairosdb_url'] = "https://github.com/kairosdb/k
 
 # Override the default java configuration
 # TODO: Configure these attributes in a way that they don't have precedence over user config
-override['java']['oracle']['accept_oracle_download_terms'] = true
-override['java']['java_home'] = "/usr/java/default"
-override['java']['jdk_version'] = 8
+default['java']['oracle']['accept_oracle_download_terms'] = true
+default['java']['install_flavor'] = 'oracle_rpm'
+default['java']['jdk_version'] = 8
 
 # Override Cassandra default configuration to make sure it is always running properly
-override['cassandra']['notify_restart'] = true
+default['cassandra']['notify_restart'] = true
 
 # Default properties
 default['abiquo']['properties']['abiquo.datacenter.id'] = node['hostname']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,6 +101,8 @@ default['abiquo']['monitoring']['kairosdb_url'] = "https://github.com/kairosdb/k
 # TODO: Configure these attributes in a way that they don't have precedence over user config
 default['java']['oracle']['accept_oracle_download_terms'] = true
 default['java']['install_flavor'] = 'oracle_rpm'
+default['java']['oracle_rpm']['type'] = 'jdk'
+default['java']['java_home'] = "/usr/java/default"
 default['java']['jdk_version'] = 8
 
 # Override Cassandra default configuration to make sure it is always running properly

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,19 +48,18 @@ default['abiquo']['tomcat']['http-port'] = 8009
 default['abiquo']['tomcat']['ajp-port'] = 8010
 default['abiquo']['tomcat']['wait-for-webapps'] = false
 
+# Override the Apache proxy configuration
+override['apache']['proxy']['order'] = "allow,deny"
+override['apache']['proxy']['deny_from']  = "none"
+override['apache']['proxy']['allow_from'] = "all"
+
 # UI Apache configuration
 default['abiquo']['ui_apache_opts'] = {}
 
 # UI app configuration attributes. These attributes will be rendered
 # in /var/www/html/ui/config/client-config-custom.json
 default['abiquo']['ui_config'] = { "config.endpoint" => "https://#{node['fqdn']}/api" }
-
-case node['abiquo']['profile']
-when 'monolithic'
-    default['abiquo']['ui_proxies'] = { '/am' => "ajp://localhost:#{node['abiquo']['tomcat']['ajp-port']}/am" }
-else
-    default['abiquo']['ui_proxies'] = {}
-end
+default['abiquo']['ui_proxies'] = {}
 
 # Wheter or not to generate a self signed certificate
 # for this host. If not, provide path to certificate,
@@ -97,11 +96,6 @@ default['abiquo']['monitoring']['db']['install'] = true
 default['abiquo']['monitoring']['emmett']['port'] = 36638
 default['abiquo']['monitoring']['kairosdb_package'] = "kairosdb-#{node['abiquo']['monitoring']['kairosdb']['version']}-#{node['abiquo']['monitoring']['kairosdb']['release']}.rpm"
 default['abiquo']['monitoring']['kairosdb_url'] = "https://github.com/kairosdb/kairosdb/releases/download/v#{node['abiquo']['monitoring']['kairosdb']['version']}/#{node['abiquo']['monitoring']['kairosdb_package']}"
-
-# Override the Apache proxy configuration
-override['apache']['proxy']['order'] = "allow,deny"
-override['apache']['proxy']['deny_from']  = "none"
-override['apache']['proxy']['allow_from'] = "all"
 
 # Override the default java configuration
 # TODO: Configure these attributes in a way that they don't have precedence over user config

--- a/recipes/install_ui.rb
+++ b/recipes/install_ui.rb
@@ -30,18 +30,18 @@ include_recipe "abiquo::certificate"
 
 case node['abiquo']['profile']
 when 'monolithic'
-    node.set['abiquo']['ui_proxies'] = node['abiquo']['ui_proxies'].merge({
+    node.set['abiquo']['ui_proxies'] = {
         '/api' => "ajp://localhost:#{node['abiquo']['tomcat']['ajp-port']}/api",
         '/legal' => "ajp://localhost:#{node['abiquo']['tomcat']['ajp-port']}/legal",
         '/am' => "ajp://localhost:#{node['abiquo']['tomcat']['ajp-port']}/am",
         '/m' => "http://localhost:#{node['abiquo']['tomcat']['http-port']}/m"
-    })
+    }.merge(node['abiquo']['ui_proxies'])
 when 'server'
-    node.set['abiquo']['ui_proxies'] = node['abiquo']['ui_proxies'].merge({
+    node.set['abiquo']['ui_proxies'] = {
         '/api' => "ajp://localhost:#{node['abiquo']['tomcat']['ajp-port']}/api",
         '/legal' => "ajp://localhost:#{node['abiquo']['tomcat']['ajp-port']}/legal",
         '/m' => "http://localhost:#{node['abiquo']['tomcat']['http-port']}/m"
-    })
+    }.merge(node['abiquo']['ui_proxies'])
 end
 
 web_app "abiquo" do

--- a/templates/default/abiquo.conf.erb
+++ b/templates/default/abiquo.conf.erb
@@ -28,21 +28,6 @@
 
     RewriteRule ^/$ /ui/ [R]
 
-    <Location /api>
-        ProxyPass ajp://localhost:<%= node['abiquo']['tomcat']['ajp-port'] %>/api
-        ProxyPassReverse ajp://localhost:<%= node['abiquo']['tomcat']['ajp-port'] %>/api
-    </Location>
-
-    <Location /m>
-        ProxyPass http://localhost:<%= node['abiquo']['tomcat']['http-port'] %>/m
-        ProxyPassReverse http://localhost:<%= node['abiquo']['tomcat']['http-port'] %>/m
-    </Location>
-
-    <Location /legal>
-        ProxyPass ajp://localhost:<%= node['abiquo']['tomcat']['ajp-port'] %>/legal
-        ProxyPassReverse ajp://localhost:<%= node['abiquo']['tomcat']['ajp-port'] %>/legal
-    </Location>
-
 <% node['abiquo']['ui_proxies'].each do |path, remote| %>
     <Location <%= path %>>
         ProxyPass <%= remote %>


### PR DESCRIPTION
UI was always rendering proxies for API, M and legal to localhost.
For frontend only or ui only profiles this is not valid.

- Moves the UI proxy config to the recipe based on the profile.