### PR TITLE
Allow to skip repo installation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,7 @@ default['abiquo']['nfs']['mountpoint'] = "/opt/vm_repository"
 default['abiquo']['nfs']['location'] = nil  # Change to something like: "127.0.0.1:/opt/vm_repository"
 
 # Yum repository configuration
+default['abiquo']['yum']['install-repo'] = true
 default['abiquo']['yum']['base-repo'] = "http://mirror.abiquo.com/abiquo/3.8/os/x86_64"
 default['abiquo']['yum']['updates-repo'] = "http://mirror.abiquo.com/abiquo/3.8/updates/x86_64"
 default['abiquo']['yum']['gpg-check'] = true

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -28,7 +28,7 @@ directory "/var/cache/yum" do
     action :nothing
 end
 
-include_recipe "yum-epel"
+include_recipe "yum-epel" if node['abiquo']['yum']['install-repo']
 
 gpg_keys = gpg_key_files.join(" ")
 
@@ -42,6 +42,7 @@ yum_repository "abiquo-base" do
     subscribes :create, "package[abiquo-release-ee]", :immediately
     notifies :delete, 'directory[/var/cache/yum]', :immediately
     notifies :run, 'execute[clean-yum-cache]', :immediately
+    only_if { node['abiquo']['yum']['install-repo'] }
 end
 
 yum_repository "abiquo-updates" do
@@ -54,6 +55,7 @@ yum_repository "abiquo-updates" do
     subscribes :create, "package[abiquo-release-ee]", :immediately
     notifies :delete, 'directory[/var/cache/yum]', :immediately
     notifies :run, 'execute[clean-yum-cache]', :immediately
+    only_if { node['abiquo']['yum']['install-repo'] }
 end
 
 # This package contains the gpgkey file, so the signature cannot
@@ -61,6 +63,7 @@ end
 package "abiquo-release-ee" do
     options "--nogpgcheck"
     action :install
+    only_if { node['abiquo']['yum']['install-repo'] }
 end
 
 package 'yum-utils' do

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -37,6 +37,12 @@ describe 'abiquo::repository' do
         expect(chef_run).to include_recipe('yum-epel')
     end
 
+    it 'does not include the yum-epel recipe if not install-repo' do
+        chef_run.node.set['abiquo']['yum']['install-repo'] = false
+        chef_run.converge(described_recipe)
+        expect(chef_run).to_not include_recipe('yum-epel')
+    end
+
     it 'creates the base repository' do
         chef_run.converge(described_recipe)
         expect(chef_run).to create_yum_repository('abiquo-base').with(
@@ -53,6 +59,12 @@ describe 'abiquo::repository' do
         expect(resource).to subscribe_to('package[abiquo-release-ee]').on(:create)
         expect(resource).to notify('directory[/var/cache/yum]').to(:delete).immediately
         expect(resource).to notify('execute[clean-yum-cache]').to(:run).immediately
+    end
+
+    it 'does not create the base repository if not install-repo' do
+        chef_run.node.set['abiquo']['yum']['install-repo'] = false
+        chef_run.converge(described_recipe)
+        expect(chef_run).to_not create_yum_repository('abiquo-base')
     end
 
     it 'creates the updates repository' do
@@ -72,12 +84,24 @@ describe 'abiquo::repository' do
         expect(resource).to notify('directory[/var/cache/yum]').to(:delete).immediately
         expect(resource).to notify('execute[clean-yum-cache]').to(:run).immediately
     end
+    
+    it 'does not create the updates repository if not install-repo' do
+        chef_run.node.set['abiquo']['yum']['install-repo'] = false
+        chef_run.converge(described_recipe)
+        expect(chef_run).to_not create_yum_repository('abiquo-updates')
+    end
 
     it 'installs the abiquo-release-ee package' do
         chef_run.converge(described_recipe)
         expect(chef_run).to install_package('abiquo-release-ee').with(
             :options => '--nogpgcheck'
         )
+    end
+
+    it 'does not install the abiquo-release-ee package if not install-repo' do
+        chef_run.node.set['abiquo']['yum']['install-repo'] = false
+        chef_run.converge(described_recipe)
+        expect(chef_run).to_not install_package('abiquo-release-ee')
     end
 
     it 'installs yum-utils package' do


### PR DESCRIPTION
Some users use Satellite systems which already provide the packages
through subscription model. In that case, they might be getting the
Abiquo packages from there, so we give the option to skip the repo
setup.