### PR TITLE
Retrieve API cert in RS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'chef', '~> 12.7.2'
 gem 'berkshelf', '~> 4.0.1'
 
-gem 'foodcritic', '~> 6.0.0', :group => :lint
+gem 'foodcritic', '~> 7.0.0', :group => :lint
 gem 'rubocop', '~> 0.42.0', :group => :lint
 gem 'chefspec', '~> 4.4.0', :group => :unit
 gem 'mysql2', '~> 0.4.4', :group => :unit

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -103,7 +103,7 @@ default['abiquo']['certificate']['ca_file'] = nil
 # Additional certs to add to Java truststore
 # Provide a url *https://somehost/* or just
 # a hostname *somehost*
-default['abiquo']['certificate']['additional_certs'] = []
+default['abiquo']['certificate']['additional_certs'] = {}
 
 # Configure abiquo KVM
 default['abiquo']['aim']['port'] = 8889

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -100,6 +100,11 @@ default['abiquo']['certificate']['file'] = "/etc/pki/abiquo/#{node['abiquo']['ce
 default['abiquo']['certificate']['key_file'] = "/etc/pki/abiquo/#{node['abiquo']['certificate']['common_name']}.key"
 default['abiquo']['certificate']['ca_file'] = nil
 
+# Additional certs to add to Java truststore
+# Provide a url *https://somehost/* or just
+# a hostname *somehost*
+default['abiquo']['certificate']['additional_certs'] = []
+
 # Configure abiquo KVM
 default['abiquo']['aim']['port'] = 8889
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,8 +101,10 @@ default['abiquo']['certificate']['key_file'] = "/etc/pki/abiquo/#{node['abiquo']
 default['abiquo']['certificate']['ca_file'] = nil
 
 # Additional certs to add to Java truststore
-# Provide a url *https://somehost/* or just
-# a hostname *somehost*
+# Provide a hash of {alias => url} or {alias => host}
+# { 'api' => 'https://somehost/' }
+# or just
+# { 'someservice' => 'someservice.local' }
 default['abiquo']['certificate']['additional_certs'] = {}
 
 # Configure abiquo KVM

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -20,4 +20,8 @@ if defined?(ChefSpec)
     def wait_abiquo_wait_for_port(service_name)
         ChefSpec::Matchers::ResourceMatcher.new(:abiquo_wait_for_port, :wait, service_name)
     end
+
+    def download_abiquo_download_cert(host_name)
+        ChefSpec::Matchers::ResourceMatcher.new(:abiquo_download_cert, :download, host_name)
+    end
 end

--- a/providers/download_cert.rb
+++ b/providers/download_cert.rb
@@ -1,0 +1,91 @@
+# Cookbook Name:: abiquo
+# Provider:: download_cert
+#
+# Copyright 2014, Abiquo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'uri'
+
+def whyrun_supported?
+    true
+end
+
+use_inline_resources
+
+action :download do
+    converge_by("Downloading SSL certificate from #{new_resource.host}") do
+        # Check the provided host is not nil.
+        # This can happen if the node has no property for
+        # abiquo.server.api.location
+        if new_resource.host.nil?
+            Chef::Log.debug 'abiquo_download_cert :: SSL API location not provided. Skipping.'
+            new_resource.updated_by_last_action(false)
+            return
+        end
+
+        # parse host
+        uri = URI.parse(new_resource.host)
+        if uri.host.nil?
+            # Give just a hostname, not URL
+            ssl_host = uri.path
+        else
+            ssl_host = uri.host
+        end
+        # SNI
+        ssl_servername = new_resource.server_name.nil? ? ssl_host : new_resource.server_name
+
+        cert_full_filename = "#{new_resource.file_path}/#{ssl_host}.crt"
+        if ::File.exist? cert_full_filename
+            Chef::Log.debug "abiquo_download_cert :: Certificate for #{ssl_host} has already been downloaded. Skipping."
+            new_resource.updated_by_last_action(false)
+            return
+        end
+
+        # Get OpenSSL context
+        ctx = OpenSSL::SSL::SSLContext.new
+
+        begin
+            # Get remote TCP socket
+            sock = TCPSocket.new(ssl_host, 443)
+
+            # pass that socket to OpenSSL
+            ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
+            ssl.hostname = ssl_servername
+
+            # establish connection, if possible
+            ssl.connect
+        rescue Exception => e
+            Chef::Log.debug "abiquo_download_cert :: Could not connect to #{ssl_host}!"
+            Chef::Log.debug 'abiquo_download_cert :: ' + e.message
+            new_resource.updated_by_last_action(false)
+            return
+        end
+
+        # get peer certificate
+        cert = ssl.peer_cert
+        
+        # Save the cert to disk
+        ::FileUtils.mkdir_p(new_resource.file_path)
+        ::File.open(cert_full_filename, 'w') do |f|
+            f.write(cert.to_s)
+        end
+
+        Chef::Log.debug 'abiquo_download_cert :: Importing the certificate into Java truststore...'
+        java_management_truststore_certificate ssl_host do
+            file cert_full_filename
+            action :import
+        end
+
+        new_resource.updated_by_last_action(true)
+    end
+end

--- a/providers/download_cert.rb
+++ b/providers/download_cert.rb
@@ -35,12 +35,7 @@ action :download do
 
         # parse host
         uri = URI.parse(new_resource.host)
-        if uri.host.nil?
-            # Give just a hostname, not URL
-            ssl_host = uri.path
-        else
-            ssl_host = uri.host
-        end
+        ssl_host = uri.host.nil? ? uri.path : uri.host
         # SNI
         ssl_servername = new_resource.server_name.nil? ? ssl_host : new_resource.server_name
 
@@ -64,7 +59,7 @@ action :download do
 
             # establish connection, if possible
             ssl.connect
-        rescue Exception => e
+        rescue => e
             Chef::Log.debug "abiquo_download_cert :: Could not connect to #{ssl_host}!"
             Chef::Log.debug 'abiquo_download_cert :: ' + e.message
             new_resource.updated_by_last_action(false)
@@ -73,7 +68,7 @@ action :download do
 
         # get peer certificate
         cert = ssl.peer_cert
-        
+
         # Save the cert to disk
         ::FileUtils.mkdir_p(new_resource.file_path)
         ::File.open(cert_full_filename, 'w') do |f|

--- a/providers/download_cert.rb
+++ b/providers/download_cert.rb
@@ -25,10 +25,10 @@ use_inline_resources
 action :download do
     converge_by("Downloading SSL certificate from #{new_resource.host}") do
         # Check the provided host is not nil.
-        # This can happen if the node has no property for
-        # abiquo.server.api.location
+        # This can happen if for some reason the name
+        # of the resource resolves to nil
         if new_resource.host.nil?
-            Chef::Log.debug 'abiquo_download_cert :: SSL API location not provided. Skipping.'
+            Chef::Log.debug 'abiquo_download_cert :: SSL location not provided. Skipping.'
             new_resource.updated_by_last_action(false)
             return
         end

--- a/recipes/certificate.rb
+++ b/recipes/certificate.rb
@@ -26,9 +26,16 @@ ssl_certificate node['abiquo']['certificate']['common_name'] do
     key_path  node['abiquo']['certificate']['key_file']
     not_if { ::File.file? "node['abiquo']['certificate']['file']" }
     only_if { node['abiquo']['certificate']['source'] == 'self-signed' }
-    notifies :restart, 'service[apache2]' unless node['abiquo']['profile'] == 'websockify'
+    notifies :restart, 'service[apache2]' if node.recipe?('abiquo::install_ui')
     notifies :import, "java_management_truststore_certificate[#{node['abiquo']['certificate']['common_name']}]", :immediately
     notifies :create, "template[#{node['abiquo']['certificate']['file']}.haproxy.crt]", :immediately
+end
+
+# Collect the API cert for RS
+if node['abiquo']['properties']['abiquo.server.api.location'] && node['abiquo']['profile'] == 'remoteservices'
+    abiquo_download_cert node['abiquo']['properties']['abiquo.server.api.location'] do
+        notifies :restart, 'service[abiquo-tomcat]'
+    end
 end
 
 template "#{node['abiquo']['certificate']['file']}.haproxy.crt" do

--- a/recipes/certificate.rb
+++ b/recipes/certificate.rb
@@ -31,18 +31,12 @@ ssl_certificate node['abiquo']['certificate']['common_name'] do
     notifies :create, "template[#{node['abiquo']['certificate']['file']}.haproxy.crt]", :immediately
 end
 
-# Collect the API cert for RS
-abiquo_download_cert 'retrieve-api-cert' do
-    host node['abiquo']['properties']['abiquo.server.api.location']
-    notifies :restart, 'service[abiquo-tomcat]' if node.recipe?('abiquo::service')
-    only_if { node['abiquo']['properties']['abiquo.server.api.location'] && node['abiquo']['profile'] == 'remoteservices' }
-end
-
 # Collect additional certs
-node['abiquo']['certificate']['additional_certs'].each do |cert|
-    abiquo_download_cert "retrieve-#{cert}-cert" do
+node['abiquo']['certificate']['additional_certs'].each do |cert_alias, cert|
+    abiquo_download_cert cert_alias do
         host cert
         notifies :restart, 'service[abiquo-tomcat]' if node.recipe?('abiquo::service')
+        action :download
     end
 end
 

--- a/recipes/certificate.rb
+++ b/recipes/certificate.rb
@@ -32,9 +32,17 @@ ssl_certificate node['abiquo']['certificate']['common_name'] do
 end
 
 # Collect the API cert for RS
-if node['abiquo']['properties']['abiquo.server.api.location'] && node['abiquo']['profile'] == 'remoteservices'
-    abiquo_download_cert node['abiquo']['properties']['abiquo.server.api.location'] do
-        notifies :restart, 'service[abiquo-tomcat]'
+abiquo_download_cert 'retrieve-api-cert' do
+    host node['abiquo']['properties']['abiquo.server.api.location']
+    notifies :restart, 'service[abiquo-tomcat]' if node.recipe?('abiquo::service')
+    only_if { node['abiquo']['properties']['abiquo.server.api.location'] && node['abiquo']['profile'] == 'remoteservices' }
+end
+
+# Collect additional certs
+node['abiquo']['certificate']['additional_certs'].each do |cert|
+    abiquo_download_cert "retrieve-#{cert}-cert" do
+        host cert
+        notifies :restart, 'service[abiquo-tomcat]' if node.recipe?('abiquo::service')
     end
 end
 

--- a/recipes/install_remoteservices.rb
+++ b/recipes/install_remoteservices.rb
@@ -21,6 +21,13 @@ end
 
 include_recipe 'java::oracle_jce'
 include_recipe 'abiquo::install_ext_services' if node['abiquo']['install_ext_services']
+
+# Add API cert as additional SSL cert if defined
+if node['abiquo']['properties']['abiquo.server.api.location']
+    node.set['abiquo']['certificate']['additional_certs'] = {
+        'api' => node['abiquo']['properties']['abiquo.server.api.location']
+    }.merge(node['abiquo']['certificate']['additional_certs'])
+end
 include_recipe 'abiquo::certificate'
 
 %w(remote-services sosreport-plugins).each do |pkg|

--- a/resources/download_cert.rb
+++ b/resources/download_cert.rb
@@ -1,5 +1,5 @@
 # Cookbook Name:: abiquo
-# Recipe:: install_remoteservices
+# Resource:: download_cert
 #
 # Copyright 2014, Abiquo
 #
@@ -11,24 +11,14 @@
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY :kind, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package 'jdk' do
-    action :install
-end
+actions :download
 
-include_recipe 'java::oracle_jce'
-include_recipe 'abiquo::install_ext_services' if node['abiquo']['install_ext_services']
-include_recipe 'abiquo::certificate'
+default_action :download
 
-%w(remote-services sosreport-plugins).each do |pkg|
-    package "abiquo-#{pkg}" do
-        action :install
-    end
-end
-
-service 'rpcbind' do
-    action [:enable, :start]
-end
+attribute :host,        :kind_of => String, :name_attribute => true
+attribute :server_name, :kind_of => String, :default => nil
+attribute :file_path,   :kind_of => String, :default => '/etc/pki/abiquo'

--- a/spec/install_remoteservices_spec.rb
+++ b/spec/install_remoteservices_spec.rb
@@ -16,7 +16,11 @@ require 'spec_helper'
 require_relative 'support/commands'
 
 describe 'abiquo::install_remoteservices' do
-    let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe, 'abiquo::service') }
+    let(:chef_run) do
+        ChefSpec::SoloRunner.new(:internal_locale => 'en_US.UTF-8') do |node|
+            node.set['abiquo']['certificate']['common_name'] = 'test.local'
+        end.converge(described_recipe, 'abiquo::service')
+    end
 
     before do
         stub_command('rabbitmqctl list_users | egrep -q \'^abiquo.*\'').and_return(false)

--- a/spec/install_remoteservices_spec.rb
+++ b/spec/install_remoteservices_spec.rb
@@ -23,6 +23,12 @@ describe 'abiquo::install_remoteservices' do
         stub_check_db_pass_command('root', '')
     end
 
+    it 'includes needed recipes' do
+        %w(java::oracle_jce abiquo::install_ext_services abiquo::certificate).each do |recipe|
+            expect(chef_run).to include_recipe(recipe)
+        end
+    end
+
     it 'installs the jdk system package' do
         expect(chef_run).to install_package('jdk')
     end


### PR DESCRIPTION
Uses a new LWRP to download the SSL certificate from a given address
(host or URI) and import it into Java truststore. Meant to be used
in RS boxes to download the API cert.