### PR TITLE
Use Abiquo websockify plugin

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -170,8 +170,7 @@ end
 default['abiquo']['websockify']['port'] = 41338
 default['abiquo']['websockify']['address'] = '127.0.0.1'
 default['abiquo']['websockify']['api_url'] = 'https://localhost/api'
-default['abiquo']['websockify']['user'] = 'admin'
-default['abiquo']['websockify']['pass'] = 'xabiquo'
+default['abiquo']['websockify']['creds'] = { api_user: 'admin', api_pass: 'xabiquo' }
 default['abiquo']['websockify']['crt'] = node['abiquo']['certificate']['file']
 default['abiquo']['websockify']['key'] = node['abiquo']['certificate']['key_file']
 default['abiquo']['haproxy']['address'] = '*'

--- a/recipes/setup_websockify.rb
+++ b/recipes/setup_websockify.rb
@@ -15,21 +15,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-file '/etc/cron.d/novnc_tokens' do
-  content "* * * * * root /opt/websockify/novnc_tokens.rb -a #{node['abiquo']['websockify']['api_url']} -u #{node['abiquo']['websockify']['user']} -p #{node['abiquo']['websockify']['pass']} -f /opt/websockify/config.vnc"
-  owner 'root'
-  group 'root'
-  mode  '0644'
-  action :create
-  notifies :restart, 'service[websockify]'
-end
-
 template '/etc/init.d/websockify' do
   source 'websockify.erb'
   owner 'root'
   group 'root'
   variables(websockify_port: node['abiquo']['websockify']['port'],
             websockify_address: node['abiquo']['websockify']['address'])
+  action :create
+  notifies :restart, 'service[websockify]'
+end
+
+template '/opt/websockify/abiquo.cfg' do
+  source 'ws_abiquo.cfg.erb'
+  owner 'root'
+  group 'root'
+  variables(creds: node['abiquo']['websockify']['creds'])
   action :create
   notifies :restart, 'service[websockify]'
 end

--- a/spec/setup_websockify_spec.rb
+++ b/spec/setup_websockify_spec.rb
@@ -37,15 +37,12 @@ describe 'abiquo::setup_websockify' do
     )
   end
 
-  it 'configures the websockify cron task' do
-    chef_run.converge('abiquo::install_websockify', described_recipe, 'abiquo::service')
-    expect(chef_run).to create_file('/etc/cron.d/novnc_tokens').with(
-      content: "* * * * * root /opt/websockify/novnc_tokens.rb -a #{chef_run.node['abiquo']['websockify']['api_url']} " \
-                   "-u #{chef_run.node['abiquo']['websockify']['user']} -p #{chef_run.node['abiquo']['websockify']['pass']} " \
-                   '-f /opt/websockify/config.vnc',
+  it 'renders websockify plugin credential files' do
+    chef_run.converge('apache2::default', 'abiquo::install_websockify', described_recipe, 'abiquo::service')
+    expect(chef_run).to create_template('/opt/websockify/abiquo.cfg').with(
+      source: 'ws_abiquo.cfg.erb',
       owner: 'root',
-      group: 'root',
-      mode: '0644'
+      group: 'root'
     )
   end
 

--- a/templates/default/websockify.erb
+++ b/templates/default/websockify.erb
@@ -22,7 +22,7 @@ WEBSOCKIFY=$BINDIR/run
 WEBSOCKIFY_ADDR=<%= @websockify_address %>
 WEBSOCKIFY_PORT=<%= @websockify_port %>
 PIDFILE=/var/run/websockify.pid
-TOKEN_FILE=$BINDIR/config.vnc
+CONFIG_FILE=$BINDIR/abiquo.cfg
 LOG_FILE=/var/log/websockify
 USER=root
 
@@ -31,7 +31,7 @@ case "$1" in
   start)
   [ -x $WEBSOCKIFY ] || exit 1
   echo -n $"Starting websockify server: "
-  daemon --user "$USER" --pidfile $PIDFILE python "$WEBSOCKIFY" -D "$WEBSOCKIFY_ADDR":"$WEBSOCKIFY_PORT" --token-plugin TokenFile --token-source="$TOKEN_FILE" --log-file="$LOG_FILE"
+  daemon --user "$USER" --pidfile $PIDFILE python "$WEBSOCKIFY" -D "$WEBSOCKIFY_ADDR":"$WEBSOCKIFY_PORT" --token-plugin websockify.abiquo_plugin.AbiquoTokenPlugin --token-source $CONFIG_FILE --log-file="$LOG_FILE"
   RETVAL=$?
   echo
   [ $RETVAL -eq 0 ] && sleep 1 && ps aux | grep [/]opt/websockify/run | awk '{print $2}' > $PIDFILE

--- a/templates/default/ws_abiquo.cfg.erb
+++ b/templates/default/ws_abiquo.cfg.erb
@@ -1,0 +1,5 @@
+[websockify]
+ssl_verify = false
+<% @creds.each do |k, v| %>
+<%= k %> = <%= v %>
+<% end %>

--- a/test/integration/frontend/serverspec/frontend_config_spec.rb
+++ b/test/integration/frontend/serverspec/frontend_config_spec.rb
@@ -62,9 +62,10 @@ describe 'Front-end configuration' do
     expect(file('/etc/haproxy/haproxy.cfg')).to contain('41337 ssl crt /etc/pki/abiquo/frontend.abiquo.com.crt.haproxy.crt')
   end
 
-  it 'has novnc_tokens cron task configured' do
-    expect(file('/etc/cron.d/novnc_tokens')).to_not be_executable
-    expect(file('/etc/cron.d/novnc_tokens')).to contain('* * * * * root /opt/websockify/novnc_tokens.rb -a https://localhost/api -u admin ' \
-                                                        '-p xabiquo -f /opt/websockify/config.vnc')
+  it 'has the config file for the websockify plugin' do
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('[websockify]')
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('ssl_verify = false')
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('api_user = admin')
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('api_pass = xabiquo')
   end
 end

--- a/test/integration/monolithic/serverspec/monolithic_config_spec.rb
+++ b/test/integration/monolithic/serverspec/monolithic_config_spec.rb
@@ -32,14 +32,16 @@ describe 'Monolithic configuration' do
     expect(file('/etc/init.d/websockify')).to contain('LOG_FILE=/var/log/websockify')
   end
 
+  it 'has the config file for the websockify plugin' do
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('[websockify]')
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('ssl_verify = false')
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('api_user = admin')
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('api_pass = xabiquo')
+  end
+
   it 'has haproxy service configured' do
     expect(file('/etc/haproxy/haproxy.cfg')).to contain('server websockify1 127.0.0.1:41338 weight 1 maxconn 1024 check')
     expect(file('/etc/haproxy/haproxy.cfg')).to contain('41337 ssl crt /etc/pki/abiquo/monolithic.abiquo.com.crt.haproxy.crt')
-  end
-
-  it 'has novnc_tokens cron task configured' do
-    expect(file('/etc/corn.d/novnc_tokens')).to_not be_executable
-    expect(file('/etc/cron.d/novnc_tokens')).to contain('* * * * * root /opt/websockify/novnc_tokens.rb -a https://localhost/api -u admin -p xabiquo -f /opt/websockify/config.vnc')
   end
 
   it 'has apache mappings to tomcat configured' do

--- a/test/integration/server/serverspec/server_config_spec.rb
+++ b/test/integration/server/serverspec/server_config_spec.rb
@@ -32,14 +32,16 @@ describe 'Server configuration' do
     expect(file('/etc/init.d/websockify')).to contain('LOG_FILE=/var/log/websockify')
   end
 
+  it 'has the config file for the websockify plugin' do
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('[websockify]')
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('ssl_verify = false')
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('api_user = admin')
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('api_pass = xabiquo')
+  end
+
   it 'has haproxy service configured' do
     expect(file('/etc/haproxy/haproxy.cfg')).to contain('server websockify1 127.0.0.1:41338 weight 1 maxconn 1024 check')
     expect(file('/etc/haproxy/haproxy.cfg')).to contain('41337 ssl crt /etc/pki/abiquo/server.abiquo.com.crt.haproxy.crt')
-  end
-
-  it 'has novnc_tokens cron task configured' do
-    expect(file('/etc/cron.d/novnc_tokens')).to_not be_executable
-    expect(file('/etc/cron.d/novnc_tokens')).to contain('* * * * * root /opt/websockify/novnc_tokens.rb -a https://localhost/api -u admin -p xabiquo -f /opt/websockify/config.vnc')
   end
 
   it 'has apache mappings to tomcat configured' do

--- a/test/integration/websockify/serverspec/websockify_config_spec.rb
+++ b/test/integration/websockify/serverspec/websockify_config_spec.rb
@@ -37,8 +37,10 @@ describe 'Websockify configuration' do
     expect(file('/etc/haproxy/haproxy.cfg')).to contain('41337 ssl crt /etc/pki/abiquo/ws.abiquo.com.crt.haproxy.crt')
   end
 
-  it 'has novnc_tokens cron task configured' do
-    expect(file('/etc/cron.d/novnc_tokens')).to_not be_executable
-    expect(file('/etc/cron.d/novnc_tokens')).to contain('* * * * * root /opt/websockify/novnc_tokens.rb -a https://localhost/api -u admin -p xabiquo -f /opt/websockify/config.vnc')
+  it 'has the config file for the websockify plugin' do
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('[websockify]')
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('ssl_verify = false')
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('api_user = admin')
+    expect(file('/opt/websockify/abiquo.cfg')).to contain('api_pass = xabiquo')
   end
 end


### PR DESCRIPTION
Ditch the noVNC token script in favor of a websockify plugin
that will retrieve the IP and port from Abiquo API on each invocation