### PR TITLE
MariaDB Msater

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,8 @@ suites:
       - recipe[abiquo::upgrade]
     attributes:
       abiquo:
+        db:
+          enable-master: true
         ui_config:
           config.endpoint: "https://monolithic.abiquo.com/api"
         ui_apache_opts:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,6 +44,7 @@ default['abiquo']['db']['user'] = 'root'
 default['abiquo']['db']['from'] = 'localhost'
 default['abiquo']['db']['password'] = nil
 default['abiquo']['db']['upgrade'] = true
+default['abiquo']['db']['enable-master'] = false
 
 # Redis configuration
 default['redisio']['servers'] = [{

--- a/recipes/install_mariadb.rb
+++ b/recipes/install_mariadb.rb
@@ -15,7 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Enable replication if specified
+node.set['mariadb']['replication']['server_id'] = '1' if node['abiquo']['db']['enable-master']
+
 include_recipe 'mariadb'
+
+# MariaDB cookbook does not restart the service after changing the config
+# files, so we subscribe to the replication config file and restart if
+# changed.
+service 'mysql' do
+  action :nothing
+  subscribes :restart, 'mariadb_configuration[replication]', :immediately
+  not_if { node['abiquo']['db']['enable-master'].nil? }
+end
 
 mysql2_chef_gem 'default' do
   provider Chef::Provider::Mysql2ChefGem::Mariadb

--- a/test/integration/monolithic/serverspec/monolithic_config_spec.rb
+++ b/test/integration/monolithic/serverspec/monolithic_config_spec.rb
@@ -104,4 +104,8 @@ describe 'Monolithic configuration' do
     expect(user('redis')).to exist
     expect(user('redis')).to have_login_shell('/bin/sh')
   end
+
+  it 'has mariadb configured as master' do
+    expect(command('mysql -e "show master status"').stdout).to contain('mariadb-bin.000')
+  end
 end


### PR DESCRIPTION
Allows to configure MariaDB as master so new slaves can replicate
from it.