### PR TITLE
Always create user for localhost

### DIFF
--- a/recipes/install_mariadb.rb
+++ b/recipes/install_mariadb.rb
@@ -40,18 +40,35 @@ conn_info = {
   password: node['mariadb']['server_root_password']
 }
 
-mysql_database_user node['abiquo']['db']['user'] do
-  connection conn_info
-  password   node['abiquo']['db']['password']
-  host       node['abiquo']['db']['from']
-  privileges [:all]
-  action     :grant
+# Need to grant for localhost to run the scripts
+kinton_grants_from = if node['abiquo']['db']['from'] != 'localhost'
+                       ['localhost', node['abiquo']['db']['from']]
+                     else
+                       ['localhost']
+                     end
+kinton_grants_from.each do |from_host|
+  mysql_database_user "kinton-#{node['abiquo']['db']['user']}-#{from_host}" do
+    connection    conn_info
+    database_name 'kinton'
+    password      node['abiquo']['db']['password']
+    host          from_host
+    privileges    [:all]
+    action        :grant
+  end
 end
 
-mysql_database_user node['abiquo']['monitoring']['db']['user'] do
-  connection conn_info
-  password   node['abiquo']['monitoring']['db']['password']
-  host       node['abiquo']['monitoring']['db']['from']
-  privileges [:all]
-  action     :grant
+watchtower_grants_from = if node['abiquo']['monitoring']['db']['from'] != 'localhost'
+                           ['localhost', node['abiquo']['monitoring']['db']['from']]
+                         else
+                           ['localhost']
+                         end
+watchtower_grants_from.each do |from_host|
+  mysql_database_user "watchtower-#{node['abiquo']['monitoring']['db']['user']}-#{from_host}" do
+    connection    conn_info
+    database_name 'watchtower'
+    password      node['abiquo']['monitoring']['db']['password']
+    host          from_host
+    privileges    [:all]
+    action        :grant
+  end
 end

--- a/spec/install_mariadb_spec.rb
+++ b/spec/install_mariadb_spec.rb
@@ -19,6 +19,7 @@ describe 'abiquo::install_mariadb' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new do |node|
       node.set['abiquo']['db']['enable-master'] = true
+      node.set['abiquo']['db']['from'] = '%'
     end.converge(described_recipe)
   end
 
@@ -41,18 +42,34 @@ describe 'abiquo::install_mariadb' do
   end
 
   it 'creates the Abiquo DB user' do
-    expect(chef_run).to grant_mysql_database_user(chef_run.node['abiquo']['db']['user'])
-    resource = chef_run.find_resource(:mysql_database_user, chef_run.node['abiquo']['db']['user'])
+    expect(chef_run).to grant_mysql_database_user("kinton-#{chef_run.node['abiquo']['db']['user']}-#{chef_run.node['abiquo']['db']['from']}")
+    resource = chef_run.find_resource(:mysql_database_user, "kinton-#{chef_run.node['abiquo']['db']['user']}-#{chef_run.node['abiquo']['db']['from']}")
     expect(resource.password).to eq(chef_run.node['abiquo']['db']['password'])
     expect(resource.host).to eq(chef_run.node['abiquo']['db']['from'])
     expect(resource.privileges).to eq([:all])
   end
 
   it 'creates the Watchtower DB user' do
-    expect(chef_run).to grant_mysql_database_user(chef_run.node['abiquo']['monitoring']['db']['user'])
-    resource = chef_run.find_resource(:mysql_database_user, chef_run.node['abiquo']['monitoring']['db']['user'])
+    expect(chef_run).to grant_mysql_database_user("watchtower-#{chef_run.node['abiquo']['monitoring']['db']['user']}-#{chef_run.node['abiquo']['monitoring']['db']['from']}")
+    resource = chef_run.find_resource(:mysql_database_user, "watchtower-#{chef_run.node['abiquo']['monitoring']['db']['user']}-#{chef_run.node['abiquo']['monitoring']['db']['from']}")
     expect(resource.password).to eq(chef_run.node['abiquo']['monitoring']['db']['password'])
     expect(resource.host).to eq(chef_run.node['abiquo']['monitoring']['db']['from'])
+    expect(resource.privileges).to eq([:all])
+  end
+
+  it 'creates the Abiquo DB user in localhost' do
+    expect(chef_run).to grant_mysql_database_user("kinton-#{chef_run.node['abiquo']['db']['user']}-localhost")
+    resource = chef_run.find_resource(:mysql_database_user, "kinton-#{chef_run.node['abiquo']['db']['user']}-localhost")
+    expect(resource.password).to eq(chef_run.node['abiquo']['db']['password'])
+    expect(resource.host).to eq('localhost')
+    expect(resource.privileges).to eq([:all])
+  end
+
+  it 'creates the Watchtower DB user in localhost' do
+    expect(chef_run).to grant_mysql_database_user("watchtower-#{chef_run.node['abiquo']['monitoring']['db']['user']}-localhost")
+    resource = chef_run.find_resource(:mysql_database_user, "watchtower-#{chef_run.node['abiquo']['monitoring']['db']['user']}-localhost")
+    expect(resource.password).to eq(chef_run.node['abiquo']['monitoring']['db']['password'])
+    expect(resource.host).to eq('localhost')
     expect(resource.privileges).to eq([:all])
   end
 end


### PR DESCRIPTION
If the user in 'from' in MariaDB grants is different from `localhost`
the scripts to create the database fail since the user has
no grants from `localhost`. We hereby force the creation on `localhost`
then create for a different host if we are asked for.