### PR TITLE
Add C7 support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,12 @@ transport:
   compression: none
 
 platforms:
-  - name: centos-6.8
+  - name: c6
+    driver:
+      box: bento/centos-6.8
+  - name: c7
+    driver:
+      box: bento/centos-7.3
 
 suites:
   - name: monolithic

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'rubocop', '~> 0.42.0', group: :lint
 gem 'chefspec', '~> 4.4.0', group: :unit
 gem 'mysql2', '~> 0.4.4', group: :unit
 gem 'hashie', '<= 3.4.4', group: :unit
+gem 'nio4r', '<= 1.2.1', group: :unit
 
 group :integration do
   gem 'serverspec', '~> 2.24.1'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,8 +32,8 @@ default['abiquo']['nfs']['location'] = nil # Change to something like: "127.0.0.
 
 # Yum repository configuration
 default['abiquo']['yum']['install-repo'] = true
-default['abiquo']['yum']['base-repo'] = 'http://mirror.abiquo.com/abiquo/3.8/os/x86_64'
-default['abiquo']['yum']['updates-repo'] = 'http://mirror.abiquo.com/abiquo/3.8/updates/x86_64'
+default['abiquo']['yum']['base-repo'] = 'http://mirror.abiquo.com/el$releasever/3.8/os/x86_64'
+default['abiquo']['yum']['updates-repo'] = 'http://mirror.abiquo.com/el$releasever/3.8/updates/x86_64'
 default['abiquo']['yum']['gpg-check'] = true
 default['abiquo']['yum']['proxy'] = nil
 

--- a/recipes/install_ui.rb
+++ b/recipes/install_ui.rb
@@ -45,7 +45,7 @@ when 'server'
 end
 
 web_app 'abiquo' do
-  template 'abiquo.conf.erb'
+  template "#{node['platform_family']}/#{node['platform_version'].to_i}/abiquo.conf.erb"
   server_name node['abiquo']['certificate']['common_name']
   cert_file node['abiquo']['certificate']['file']
   key_file node['abiquo']['certificate']['key_file']

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -47,7 +47,7 @@ describe 'abiquo::repository' do
     chef_run.converge(described_recipe)
     expect(chef_run).to create_yum_repository('abiquo-base').with(
       description: 'Abiquo base repository',
-      baseurl: 'http://mirror.abiquo.com/abiquo/3.8/os/x86_64',
+      baseurl: 'http://mirror.abiquo.com/el$releasever/3.8/os/x86_64',
       gpgcheck: true,
       gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Abiquo ' \
                  'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-MariaDB ' \
@@ -71,7 +71,7 @@ describe 'abiquo::repository' do
     chef_run.converge(described_recipe)
     expect(chef_run).to create_yum_repository('abiquo-updates').with(
       description: 'Abiquo updates repository',
-      baseurl: 'http://mirror.abiquo.com/abiquo/3.8/updates/x86_64',
+      baseurl: 'http://mirror.abiquo.com/el$releasever/3.8/updates/x86_64',
       gpgcheck: true,
       gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Abiquo ' \
                  'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-MariaDB ' \

--- a/templates/rhel/6/abiquo.conf.erb
+++ b/templates/rhel/6/abiquo.conf.erb
@@ -1,0 +1,55 @@
+<% node['apache']['listen_ports'].each do |port| -%>
+<% if port != 443 -%>
+<VirtualHost *:<%= port %>>
+    RewriteEngine On
+    RewriteRule .* https://%{SERVER_NAME}%{REQUEST_URI} [L,R=301]
+</VirtualHost>
+<% end %>
+<% end %>
+
+<VirtualHost *:443>
+    ServerName <%= @params[:server_name] %>
+    DocumentRoot "/var/www/html"
+    RewriteEngine On
+    ProxyRequests Off
+    ProxyPreserveHost On
+    ProxyTimeout <%= node['apache']['timeout'] %>
+
+    <% node['abiquo']['ui_apache_opts'].each do |opt, val| %>
+    <%= opt %> <%= val %>
+    <% end %>
+
+    <Directory "/var/www/html/ui">
+        Options MultiViews FollowSymLinks
+        AllowOverride None
+        Order allow,deny
+        Allow from all
+    </Directory>
+
+    RewriteRule ^/$ /ui/ [R]
+
+<% node['abiquo']['ui_proxies'].each do |local_path, proxy| %>
+    <Location <%= local_path %>>
+        ProxyPass <%= proxy['url'] %>
+        ProxyPassReverse <%= proxy['url'] %>
+        <% if proxy.key? 'options' %>
+        <% proxy['options'].each do |opt, value| %>
+        <%= opt %> <%= value %>
+        <% end %>
+        <% end %>
+    </Location>
+<% end %>
+
+    SSLEngine on
+    SSLProtocol All -SSLv2 -SSLv3
+    SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
+    <% unless @params[:cert_file].nil? %>
+    SSLCertificateFile <%= @params[:cert_file] %>
+    <% end %>
+    <% unless @params[:key_file].nil? %>
+    SSLCertificateKeyFile <%= @params[:key_file] %>
+    <% end %>
+    <% unless @params[:ca_file].nil? %>
+    SSLCACertificateFile <%= @params[:ca_file] %>
+    <% end %>
+</VirtualHost>

--- a/templates/rhel/7/abiquo.conf.erb
+++ b/templates/rhel/7/abiquo.conf.erb
@@ -1,0 +1,55 @@
+<% node['apache']['listen_ports'].each do |port| -%>
+<% if port != 443 -%>
+<VirtualHost *:<%= port %>>
+    RewriteEngine On
+    RewriteRule .* https://%{SERVER_NAME}%{REQUEST_URI} [L,R=301]
+</VirtualHost>
+<% end %>
+<% end %>
+
+<VirtualHost *:443>
+    ServerName <%= @params[:server_name] %>
+    DocumentRoot "/var/www/html"
+    RewriteEngine On
+    ProxyRequests Off
+    ProxyPreserveHost On
+    ProxyTimeout <%= node['apache']['timeout'] %>
+
+    <% node['abiquo']['ui_apache_opts'].each do |opt, val| %>
+    <%= opt %> <%= val %>
+    <% end %>
+
+    <Directory "/var/www/html/ui">
+        Options MultiViews FollowSymLinks
+        AllowOverride None
+        Require all granted
+    </Directory>
+
+    RewriteRule ^/$ /ui/ [R]
+
+<% node['abiquo']['ui_proxies'].each do |local_path, proxy| %>
+    <Location <%= local_path %>>
+        ProxyPass <%= proxy['url'] %>
+        ProxyPassReverse <%= proxy['url'] %>
+        <% if proxy.key? 'options' %>
+        <% proxy['options'].each do |opt, value| %>
+        <%= opt %> <%= value %>
+        <% end %>
+        <% end %>
+    </Location>
+<% end %>
+
+    SSLEngine on
+    SSLCompression off
+    SSLProtocol All -SSLv2 -SSLv3
+    SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
+    <% unless @params[:cert_file].nil? %>
+    SSLCertificateFile <%= @params[:cert_file] %>
+    <% end %>
+    <% unless @params[:key_file].nil? %>
+    SSLCertificateKeyFile <%= @params[:key_file] %>
+    <% end %>
+    <% unless @params[:ca_file].nil? %>
+    SSLCACertificateFile <%= @params[:ca_file] %>
+    <% end %>
+</VirtualHost>


### PR DESCRIPTION
Adds support for CentOS 7.

- Change the default repos to include releasever variable. Pending
on a decision on repo structure.
- Renders Apache config for 2.2 or 2.4 based on platform version.