### PR TITLE
Add new setup for HAproxy and WS on remoteservices

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -90,6 +90,12 @@ suites:
               Header: add "Access-Control-Allow-Origin" "*"
         certificate:
           common_name: frontend.abiquo.com
+        haproxy:
+          ws_paths:
+            /somePath: 
+              - 10.10.10.10
+            /someOtherPath: 
+              - 20.20.20.20
   - name: ui
     run_list:
       - recipe[abiquo::default]
@@ -120,6 +126,10 @@ suites:
     attributes:
       abiquo:
         profile: remoteservices
+        yum:
+          base-repo: http://q683q694b6:973kkkfzhh@mirror.abiquo.com/abiquo/3.10-SNAPSHOT/os/x86_64
+          updates-repo: http://10.60.20.42/master/rpm
+          gpg-check: false
   - name: v2v
     run_list:
       - recipe[abiquo::default]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,7 @@ provisioner:
   name: chef_zero
   require_chef_omnibus: 12.5.1
   data_path: test/fixtures
+  nodes_path: test/nodes
 
 transport:
   compression: none
@@ -69,6 +70,13 @@ suites:
             url: http://some_am:8009/am
         certificate:
           common_name: server.abiquo.com
+        haproxy:
+          use_default_path: true
+          ws_paths:
+            /somePath: 
+              - 10.10.10.10:41338
+            /someOtherPath: 
+              - 20.20.20.20:41338
   - name: frontend
     run_list:
       - recipe[abiquo::default]
@@ -93,9 +101,9 @@ suites:
         haproxy:
           ws_paths:
             /somePath: 
-              - 10.10.10.10
+              - 10.10.10.10:41338
             /someOtherPath: 
-              - 20.20.20.20
+              - 20.20.20.20:41338
   - name: ui
     run_list:
       - recipe[abiquo::default]
@@ -110,6 +118,8 @@ suites:
           client.test.timeout: 600
         certificate:
           common_name: server.abiquo.com
+        haproxy:
+          node_search_query: role:remoteservices
   - name: websockify
     run_list:
       - recipe[abiquo::default]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -172,7 +172,12 @@ default['abiquo']['websockify']['api_url'] = 'https://localhost/api'
 default['abiquo']['websockify']['creds'] = { api_user: 'admin', api_pass: 'xabiquo' }
 default['abiquo']['websockify']['crt'] = node['abiquo']['certificate']['file']
 default['abiquo']['websockify']['key'] = node['abiquo']['certificate']['key_file']
+default['haproxy']['enable_default_http'] = false
 default['abiquo']['haproxy']['address'] = '*'
 default['abiquo']['haproxy']['port'] = 41337
 default['abiquo']['haproxy']['certificate'] = "#{node['abiquo']['certificate']['file']}.haproxy.crt"
-default['haproxy']['enable_default_http'] = false
+# TMP
+# Define WS paths as attributes. This wwil be moved to a search
+# on upcoming releases
+# eg. { '/path' => [websockify_ip] }
+default['abiquo']['haproxy']['ws_paths'] = {}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -181,3 +181,5 @@ default['abiquo']['haproxy']['certificate'] = "#{node['abiquo']['certificate']['
 # on upcoming releases
 # eg. { '/path' => [websockify_ip] }
 default['abiquo']['haproxy']['ws_paths'] = {}
+default['abiquo']['haproxy']['node_search_query'] = nil
+default['abiquo']['haproxy']['use_default_path'] = false

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -13,8 +13,33 @@
 # limitations under the License.
 
 require 'chef/platform'
+require 'digest/sha1'
 
 module Abiquo
+  module Search
+    def search_websockify(query_str)
+      paths = {}
+      nodes = Chef::Search::Query.new.search(:node, query_str).first || []
+      Chef::Log.info('No nodes returned by the search query') if nodes.count.zero?
+      nodes.each do |rnode|
+        begin
+          if rnode['abiquo']['properties']['abiquo.datacenter.id'].nil? || rnode['abiquo']['websockify']['port'].nil?
+            # Skip the host if does not have dc id property and ws port
+            Chef::Log.info("Node #{node['hostname']} does not have DC id property or Websockify port set. Skipping.")
+            next
+          end
+        rescue NoMethodError
+          Chef::Log.info("Node #{node['hostname']} does not have DC id property or Websockify port set. Skipping.")
+          next
+        end
+        idhash = Digest::SHA1.hexdigest(rnode['abiquo']['properties']['abiquo.datacenter.id'])
+        dest = "#{rnode['ipaddress']}:#{rnode['abiquo']['websockify']['port']}"
+        paths[idhash] = [dest]
+      end
+      paths
+    end
+  end
+
   module Packages
     include Chef::Mixin::ShellOut
 

--- a/recipes/install_frontend.rb
+++ b/recipes/install_frontend.rb
@@ -16,4 +16,3 @@
 # limitations under the License.
 
 include_recipe 'abiquo::install_ui'
-include_recipe 'abiquo::install_websockify'

--- a/recipes/install_remoteservices.rb
+++ b/recipes/install_remoteservices.rb
@@ -39,3 +39,5 @@ end
 service 'rpcbind' do
   action [:enable, :start]
 end
+
+include_recipe 'abiquo::install_websockify'

--- a/recipes/install_websockify.rb
+++ b/recipes/install_websockify.rb
@@ -30,27 +30,3 @@ service 'websockify' do
 end
 
 include_recipe 'abiquo::certificate'
-
-include_recipe 'haproxy-ng::install'
-include_recipe 'haproxy-ng::service'
-
-haproxy_backend 'ws' do
-  balance 'source'
-  servers [
-    { 'name' => 'websockify1',
-      'address' => node['abiquo']['websockify']['address'],
-      'port' => node['abiquo']['websockify']['port'],
-      'config' => 'weight 1 maxconn 1024 check' }
-  ]
-  config [
-    'timeout queue 3600s',
-    'timeout server 3600s',
-    'timeout connect 3600s'
-  ]
-end
-
-haproxy_frontend 'public' do
-  bind "#{node['abiquo']['haproxy']['address']}:#{node['abiquo']['haproxy']['port']} ssl crt #{node['abiquo']['haproxy']['certificate']}"
-  default_backend 'ws'
-  config ['timeout client 3600s']
-end

--- a/recipes/setup_frontend.rb
+++ b/recipes/setup_frontend.rb
@@ -16,4 +16,3 @@
 # limitations under the License.
 
 include_recipe 'abiquo::setup_ui'
-include_recipe 'abiquo::setup_websockify'

--- a/recipes/setup_remoteservices.rb
+++ b/recipes/setup_remoteservices.rb
@@ -24,4 +24,6 @@ unless node['abiquo']['nfs']['location'].nil? # ~FC023
   end
 end
 
+include_recipe 'abiquo::setup_websockify'
+
 include_recipe 'abiquo::service'

--- a/recipes/setup_ui.rb
+++ b/recipes/setup_ui.rb
@@ -26,8 +26,12 @@ end
 
 ws_proxies = []
 ws_proxies << resources(haproxy_frontend: 'public')
-node['abiquo']['haproxy']['ws_paths'].each do |path, _dest|
-  ws_proxies << resources(haproxy_backend: path.downcase.tr('/', '_'))
+if node['abiquo']['haproxy']['use_default_path']
+  ws_proxies << resources(haproxy_backend: 'ws')
+else
+  node['abiquo']['haproxy']['ws_paths'].each do |path, _dest|
+    ws_proxies << resources(haproxy_backend: path.downcase.tr('/', '_'))
+  end
 end
 node.set['abiquo']['haproxy']['ws_proxies'] = ws_proxies
 

--- a/recipes/setup_websockify.rb
+++ b/recipes/setup_websockify.rb
@@ -33,8 +33,3 @@ template '/opt/websockify/abiquo.cfg' do
   action :create
   notifies :restart, 'service[websockify]'
 end
-
-haproxy_instance 'haproxy' do
-  proxies [resources(haproxy_frontend: 'public'), resources(haproxy_backend: 'ws')]
-  tuning ['maxconn 1024']
-end

--- a/spec/install_frontend_spec.rb
+++ b/spec/install_frontend_spec.rb
@@ -31,9 +31,7 @@ describe 'abiquo::install_frontend' do
     stub_command('rabbitmqctl list_users | egrep -q \'^abiquo.*\'').and_return(false)
   end
 
-  %w(ui websockify).each do |recipe|
-    it "includes the #{recipe} install recipe" do
-      expect(chef_run).to include_recipe("abiquo::install_#{recipe}")
-    end
+  it 'includes the ui install recipe' do
+    expect(chef_run).to include_recipe('abiquo::install_ui')
   end
 end

--- a/spec/install_remoteservices_spec.rb
+++ b/spec/install_remoteservices_spec.rb
@@ -47,4 +47,8 @@ describe 'abiquo::install_remoteservices' do
     expect(chef_run).to enable_service('rpcbind')
     expect(chef_run).to start_service('rpcbind')
   end
+
+  it 'includes the install_websockify recipe' do
+    expect(chef_run).to include_recipe('abiquo::install_websockify')
+  end
 end

--- a/spec/install_ui_spec.rb
+++ b/spec/install_ui_spec.rb
@@ -58,7 +58,7 @@ describe 'abiquo::install_ui' do
   end
 
   it 'sets up the haproxy frontend' do
-    chef_run.node.set['abiquo']['haproxy']['ws_paths'] = { '/somePath' => ['10.10.10.10'], '/someOtherPath' => ['20.20.20.20'] }
+    chef_run.node.set['abiquo']['haproxy']['ws_paths'] = { '/somePath' => ['10.10.10.10:41338'], '/someOtherPath' => ['20.20.20.20:41338'] }
     chef_run.converge('apache2::default', described_recipe, 'abiquo::service')
     expect(chef_run).to create_haproxy_frontend('public').with(
       bind: "#{chef_run.node['abiquo']['haproxy']['address']}:#{chef_run.node['abiquo']['haproxy']['port']} ssl crt #{chef_run.node['abiquo']['haproxy']['certificate']}",
@@ -75,7 +75,7 @@ describe 'abiquo::install_ui' do
   end
 
   it 'sets up the haproxy backends' do
-    chef_run.node.set['abiquo']['haproxy']['ws_paths'] = { '/somePath' => ['10.10.10.10'], '/someOtherPath' => ['20.20.20.20'] }
+    chef_run.node.set['abiquo']['haproxy']['ws_paths'] = { '/somePath' => ['10.10.10.10:41338'], '/someOtherPath' => ['20.20.20.20:41338'] }
     chef_run.converge('apache2::default', described_recipe, 'abiquo::service')
 
     expect(chef_run).to create_haproxy_backend('_somepath').with(
@@ -84,7 +84,7 @@ describe 'abiquo::install_ui' do
       servers: [
         { 'name' => 'websockify0',
           'address' => '10.10.10.10',
-          'port' => chef_run.node['abiquo']['websockify']['port'],
+          'port' => '41338',
           'config' => 'weight 1 maxconn 1024 check' }
       ],
       config: [
@@ -101,7 +101,7 @@ describe 'abiquo::install_ui' do
       servers: [
         { 'name' => 'websockify0',
           'address' => '20.20.20.20',
-          'port' => chef_run.node['abiquo']['websockify']['port'],
+          'port' => '41338',
           'config' => 'weight 1 maxconn 1024 check' }
       ],
       config: [

--- a/spec/install_ui_spec.rb
+++ b/spec/install_ui_spec.rb
@@ -50,4 +50,66 @@ describe 'abiquo::install_ui' do
 
   # The apache webapp calls can't be tested because it is not a LWRP
   # but a definition and does not exist in the resource list
+
+  it 'installs haproxy' do
+    chef_run.converge('apache2::default', described_recipe, 'abiquo::service')
+    expect(chef_run).to include_recipe('haproxy-ng::install')
+    expect(chef_run).to include_recipe('haproxy-ng::service')
+  end
+
+  it 'sets up the haproxy frontend' do
+    chef_run.node.set['abiquo']['haproxy']['ws_paths'] = { '/somePath' => ['10.10.10.10'], '/someOtherPath' => ['20.20.20.20'] }
+    chef_run.converge('apache2::default', described_recipe, 'abiquo::service')
+    expect(chef_run).to create_haproxy_frontend('public').with(
+      bind: "#{chef_run.node['abiquo']['haproxy']['address']}:#{chef_run.node['abiquo']['haproxy']['port']} ssl crt #{chef_run.node['abiquo']['haproxy']['certificate']}",
+      acls: [
+        { 'name' => '_somepath', 'criterion' => 'path /somePath' },
+        { 'name' => '_someotherpath', 'criterion' => 'path /someOtherPath' }
+      ],
+      use_backends: [
+        { 'backend' => '_somepath', 'condition' => 'if _somepath' },
+        { 'backend' => '_someotherpath', 'condition' => 'if _someotherpath' }
+      ],
+      config: ['timeout client 3600s', 'log global']
+    )
+  end
+
+  it 'sets up the haproxy backends' do
+    chef_run.node.set['abiquo']['haproxy']['ws_paths'] = { '/somePath' => ['10.10.10.10'], '/someOtherPath' => ['20.20.20.20'] }
+    chef_run.converge('apache2::default', described_recipe, 'abiquo::service')
+
+    expect(chef_run).to create_haproxy_backend('_somepath').with(
+      balance: 'source',
+      mode: 'http',
+      servers: [
+        { 'name' => 'websockify0',
+          'address' => '10.10.10.10',
+          'port' => chef_run.node['abiquo']['websockify']['port'],
+          'config' => 'weight 1 maxconn 1024 check' }
+      ],
+      config: [
+        'log global',
+        'timeout queue 3600s',
+        'timeout server 3600s',
+        'timeout connect 3600s'
+      ]
+    )
+
+    expect(chef_run).to create_haproxy_backend('_someotherpath').with(
+      balance: 'source',
+      mode: 'http',
+      servers: [
+        { 'name' => 'websockify0',
+          'address' => '20.20.20.20',
+          'port' => chef_run.node['abiquo']['websockify']['port'],
+          'config' => 'weight 1 maxconn 1024 check' }
+      ],
+      config: [
+        'log global',
+        'timeout queue 3600s',
+        'timeout server 3600s',
+        'timeout connect 3600s'
+      ]
+    )
+  end
 end

--- a/spec/install_websockify_spec.rb
+++ b/spec/install_websockify_spec.rb
@@ -51,37 +51,4 @@ describe 'abiquo::install_websockify' do
     chef_run.converge('apache2::default', described_recipe, 'abiquo::service')
     expect(chef_run).to include_recipe('abiquo::certificate')
   end
-
-  it 'installs haproxy' do
-    chef_run.converge('apache2::default', described_recipe, 'abiquo::service')
-    expect(chef_run).to include_recipe('haproxy-ng::install')
-    expect(chef_run).to include_recipe('haproxy-ng::service')
-  end
-
-  it 'sets up the haproxy frontend' do
-    chef_run.converge('apache2::default', described_recipe, 'abiquo::service')
-    expect(chef_run).to create_haproxy_frontend('public').with(
-      bind: "#{chef_run.node['abiquo']['haproxy']['address']}:#{chef_run.node['abiquo']['haproxy']['port']} ssl crt #{chef_run.node['abiquo']['haproxy']['certificate']}",
-      default_backend: 'ws',
-      config: ['timeout client 3600s']
-    )
-  end
-
-  it 'sets up the haproxy backend' do
-    chef_run.converge('apache2::default', described_recipe, 'abiquo::service')
-    expect(chef_run).to create_haproxy_backend('ws').with(
-      balance: 'source',
-      servers: [
-        { 'name' => 'websockify1',
-          'address' => chef_run.node['abiquo']['websockify']['address'],
-          'port' => chef_run.node['abiquo']['websockify']['port'],
-          'config' => 'weight 1 maxconn 1024 check' }
-      ],
-      config: [
-        'timeout queue 3600s',
-        'timeout server 3600s',
-        'timeout connect 3600s'
-      ]
-    )
-  end
 end

--- a/spec/setup_frontend_spec.rb
+++ b/spec/setup_frontend_spec.rb
@@ -19,7 +19,7 @@ describe 'abiquo::setup_frontend' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new do |node|
       node.set['abiquo']['certificate']['common_name'] = 'test.local'
-    end.converge('apache2::default', 'abiquo::install_websockify', described_recipe, 'abiquo::service')
+    end.converge('apache2::default', 'abiquo::install_ui', described_recipe, 'abiquo::service')
   end
   let(:cn) { 'test.local' }
 
@@ -31,9 +31,7 @@ describe 'abiquo::setup_frontend' do
     stub_command('rabbitmqctl list_users | egrep -q \'^abiquo.*\'').and_return(false)
   end
 
-  %w(ui websockify).each do |recipe|
-    it "includes the #{recipe} setup recipe" do
-      expect(chef_run).to include_recipe("abiquo::setup_#{recipe}")
-    end
+  it 'includes the ui setup recipe' do
+    expect(chef_run).to include_recipe('abiquo::setup_ui')
   end
 end

--- a/spec/setup_ui_spec.rb
+++ b/spec/setup_ui_spec.rb
@@ -36,4 +36,9 @@ describe 'abiquo::setup_ui' do
       group: 'root'
     )
   end
+
+  it 'creates the haproxy instance' do
+    chef_run.converge('abiquo::install_ui', described_recipe, 'abiquo::service')
+    expect(chef_run).to create_haproxy_instance('haproxy')
+  end
 end

--- a/spec/setup_websockify_spec.rb
+++ b/spec/setup_websockify_spec.rb
@@ -45,9 +45,4 @@ describe 'abiquo::setup_websockify' do
       group: 'root'
     )
   end
-
-  it 'creates the haproxy instance' do
-    chef_run.converge('abiquo::install_websockify', described_recipe, 'abiquo::service')
-    expect(chef_run).to create_haproxy_instance('haproxy')
-  end
 end

--- a/test/integration/ui/serverspec/ui_config_spec.rb
+++ b/test/integration/ui/serverspec/ui_config_spec.rb
@@ -51,4 +51,17 @@ describe 'UI configuration' do
     expect(file('/var/www/html/ui/config/client-config-custom.json')).to contain('"client.test.timeout": 600')
     expect(file('/var/www/html/ui/config/client-config-custom.json')).to contain('"config.endpoint": "https://server.abiquo.com/api"')
   end
+
+  it 'has the right backends for the search' do
+    expect(file('/etc/haproxy/haproxy.cfg')).to exist
+    expect(file('/etc/haproxy/haproxy.cfg')).to contain('"client.backto.url": "http://google.com"')
+
+    expect(file('/etc/haproxy/haproxy.cfg')).to contain('acl edce1347bb2ea28a455769a1ea4c92449e5dc1ee path edce1347bb2ea28a455769a1ea4c92449e5dc1ee')
+    expect(file('/etc/haproxy/haproxy.cfg')).to contain('acl b7cb0f38c6c7b16036802f3cd78e75f818bafab6 path b7cb0f38c6c7b16036802f3cd78e75f818bafab6')
+    expect(file('/etc/haproxy/haproxy.cfg')).to contain('use_backend edce1347bb2ea28a455769a1ea4c92449e5dc1ee if edce1347bb2ea28a455769a1ea4c92449e5dc1ee')
+    expect(file('/etc/haproxy/haproxy.cfg')).to contain('use_backend b7cb0f38c6c7b16036802f3cd78e75f818bafab6 if b7cb0f38c6c7b16036802f3cd78e75f818bafab6')
+
+    expect(file('/etc/haproxy/haproxy.cfg')).to contain('server websockify0 10.0.0.75:41338 weight 1 maxconn 1024 check')
+    expect(file('/etc/haproxy/haproxy.cfg')).to contain('server websockify0 10.0.1.75:41338 weight 1 maxconn 1024 check')
+  end
 end

--- a/test/nodes/rs1.json
+++ b/test/nodes/rs1.json
@@ -1,0 +1,20 @@
+{
+  "name": "rs1",
+  "chef_type": "node",
+  "json_class": "Chef::Node",
+  "chef_environment": "_default",
+  "run_list": ["role[remoteservices]"],
+  "automatic": {
+    "ipaddress": "10.0.0.75"
+  },
+  "default": {
+    "abiquo": {
+      "properties": {
+        "abiquo.datacenter.id": "rs1"
+      },
+      "websockify": {
+        "port": 41338
+      }
+    }
+  }
+}

--- a/test/nodes/rs2.json
+++ b/test/nodes/rs2.json
@@ -1,0 +1,20 @@
+{
+  "name": "rs2",
+  "chef_type": "node",
+  "json_class": "Chef::Node",
+  "chef_environment": "_default",
+  "run_list": ["role[remoteservices]"],
+  "automatic": {
+    "ipaddress": "10.0.1.75"
+  },
+  "default": {
+    "abiquo": {
+      "properties": {
+        "abiquo.datacenter.id": "rs2"
+      },
+      "websockify": {
+        "port": 41338
+      }
+    }
+  }
+}

--- a/test/nodes/rs3.json
+++ b/test/nodes/rs3.json
@@ -1,0 +1,17 @@
+{
+  "name": "rs3",
+  "chef_type": "node",
+  "json_class": "Chef::Node",
+  "chef_environment": "_default",
+  "run_list": ["role[remoteservices]"],
+  "automatic": {
+    "ipaddress": "10.0.3.75"
+  },
+  "default": {
+    "abiquo": {
+      "properties": {
+        "abiquo.datacenter.id": "rs3"
+      }
+    }
+  }
+}

--- a/test/nodes/rs4.json
+++ b/test/nodes/rs4.json
@@ -1,0 +1,17 @@
+{
+  "name": "rs4",
+  "chef_type": "node",
+  "json_class": "Chef::Node",
+  "chef_environment": "_default",
+  "run_list": ["role[remoteservices]"],
+  "automatic": {
+    "ipaddress": "10.0.4.75"
+  },
+  "default": {
+    "abiquo": {
+      "websockify": {
+        "port": 41338
+      }
+    }
+  }
+}

--- a/test/nodes/rs5.json
+++ b/test/nodes/rs5.json
@@ -1,0 +1,20 @@
+{
+  "name": "rs5",
+  "chef_type": "node",
+  "json_class": "Chef::Node",
+  "chef_environment": "_default",
+  "run_list": ["role[somerole]"],
+  "automatic": {
+    "ipaddress": "10.0.5.75"
+  },
+  "default": {
+    "abiquo": {
+      "properties": {
+        "abiquo.datacenter.id": "rs5"
+      },
+      "websockify": {
+        "port": 41338
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the ability to specify the backends to setup on HAproxy. Also moves the websockify installation to remote services. 2 ways to build the backends:

- Attribute based. Use the `['abiquo']['haproxy']['ws_paths']` attribute to provide the paths and backends in a hash.
- Search based. Set the `['abiquo']['haproxy']['node_search_query']` attribute to a search that will return RS nodes. From them the path is computed based on SHA1 of the `abiquo.datacenter.id` property.

Also adds an attribute to simply use a default backend, falling back to the previous behaviour.