### PR TITLE
Model changes

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -50,9 +50,9 @@ module Abiquo
 
     def liquibase_cmd(command, props, monitoring = false)
       liquibasecmd = if monitoring
-                       "abiquo-watchtower-liquibase -h #{props['host']}"
+                       "watchtower-db -h #{props['host']}"
                      else
-                       "abiquo-liquibase -h #{props['host']}"
+                       "abiquo-db -h #{props['host']}"
                      end
       liquibasecmd += " -P #{props['port']}"
       liquibasecmd += " -u #{props['user']}"

--- a/recipes/install_database.rb
+++ b/recipes/install_database.rb
@@ -39,7 +39,7 @@ mysql_database 'kinton' do
 end
 
 execute 'install-database' do
-  command "#{mysqlcmd} kinton </usr/share/doc/abiquo-server/database/kinton-schema.sql"
+  command "#{mysqlcmd} kinton </usr/share/doc/abiquo-model/database/kinton-schema.sql"
   action :nothing
   notifies :run, 'ruby_block[extract-m-user-password]', :immediately
   notifies :query, 'mysql_database[install-license]', :immediately

--- a/spec/install_monitoring_spec.rb
+++ b/spec/install_monitoring_spec.rb
@@ -77,7 +77,7 @@ describe 'abiquo::install_monitoring' do
     expect(resource).to notify('execute[watchtower-liquibase-update]').to(:run).immediately
 
     resource = chef_run.find_resource(:execute, 'watchtower-liquibase-update')
-    expect(resource.command).to eq('abiquo-watchtower-liquibase -h localhost -P 3306 -u root update')
+    expect(resource.command).to eq('watchtower-db -h localhost -P 3306 -u root update')
   end
 
   it 'does not install the database if not configured' do

--- a/spec/upgrade_spec.rb
+++ b/spec/upgrade_spec.rb
@@ -201,7 +201,7 @@ describe 'abiquo::upgrade' do
     expect(resource).to subscribe_to('package[abiquo-server]').on(:run).immediately
     expect(resource).to do_nothing
     expect(resource.cwd).to eq('/usr/share/doc/abiquo-server/database')
-    expect(resource.command).to eq('abiquo-liquibase -h localhost -P 3306 -u root update')
+    expect(resource.command).to eq('abiquo-db -h localhost -P 3306 -u root update')
     expect(resource).to notify('service[abiquo-tomcat]').to(:restart).delayed
   end
 
@@ -215,7 +215,7 @@ describe 'abiquo::upgrade' do
     expect(resource).to subscribe_to('package[abiquo-server]').on(:run).immediately
     expect(resource).to do_nothing
     expect(resource.cwd).to eq('/usr/share/doc/abiquo-server/database')
-    expect(resource.command).to eq('abiquo-liquibase -h 127.0.0.1 -P 3306 -u root -p abiquo update')
+    expect(resource.command).to eq('abiquo-db -h 127.0.0.1 -P 3306 -u root -p abiquo update')
     expect(resource).to notify('service[abiquo-tomcat]').to(:restart).delayed
   end
 
@@ -235,7 +235,7 @@ describe 'abiquo::upgrade' do
     chef_run.converge('apache2::default', 'abiquo::install_server', 'abiquo::service', described_recipe)
     resource = chef_run.find_resource(:execute, 'watchtower-liquibase-update')
     expect(resource).to do_nothing
-    expect(resource.command).to eq('abiquo-watchtower-liquibase -h localhost -P 3306 -u root update')
+    expect(resource.command).to eq('watchtower-db -h localhost -P 3306 -u root update')
     # We can't test this if there is no explicit resource notifying it, due to how ChefSpec subscription matchers are implemented
     # expect(resource).to subscribe_to('package[abiquo-delorean]')
     expect(resource).to notify('service[abiquo-delorean]').to(:restart).delayed


### PR DESCRIPTION
Due to RPM changes and command renaming, the path to DB files has
changes as well as the commands to run liquibase.