### PR TITLE
Fix SSL check in kitchen tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The available profiles are:
 
 When installing the Abiquo Monolithic profile, you may also want to set the `node['abiquo']['certificate']`
 properties so the right certificate is used or a self-signed one is generated. You can also use it together
-with the [hostname](http://community.opscode.com/cookbooks/hostname) cookbook to make sure the node will have it properly configured.
+with the [hostnames](http://community.opscode.com/cookbooks/hostnames) cookbook to make sure the node will have it properly configured.
 
 # Testing
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,7 +48,7 @@ default['abiquo']['db']['enable-master'] = false
 
 # Redis configuration
 default['redisio']['servers'] = [{
-  'name' => '-master',
+  'name' => 'master',
   'port' => 6379,
   'address' => '0.0.0.0'
 }]

--- a/recipes/setup_websockify.rb
+++ b/recipes/setup_websockify.rb
@@ -15,14 +15,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-template '/etc/init.d/websockify' do
-  source 'websockify.erb'
-  owner 'root'
-  group 'root'
-  variables(websockify_port: node['abiquo']['websockify']['port'],
-            websockify_address: node['abiquo']['websockify']['address'])
-  action :create
-  notifies :restart, 'service[websockify]'
+if node['platform_version'].to_i == 7
+  template '/etc/sysconfig/websockify' do
+    source "#{node['platform_family']}/#{node['platform_version'].to_i}/conf-websockify.erb"
+    owner 'root'
+    group 'root'
+    action :create
+    notifies :restart, 'service[websockify]'
+  end
+else
+  template '/etc/init.d/websockify' do
+    source 'websockify.erb'
+    owner 'root'
+    group 'root'
+    variables(websockify_port: node['abiquo']['websockify']['port'],
+              websockify_address: node['abiquo']['websockify']['address'])
+    action :create
+    notifies :restart, 'service[websockify]'
+  end
 end
 
 template '/opt/websockify/abiquo.cfg' do

--- a/templates/rhel/6/websockify.erb
+++ b/templates/rhel/6/websockify.erb
@@ -1,0 +1,63 @@
+#!/bin/sh
+#
+# websockify   This shell script takes care of starting and stopping
+#              the websockify server.
+#
+# chkconfig: 2345 90 10
+# description: websockify server.
+# processname: websockify
+# pidfile: /var/websockify/websockify.pid
+
+# Installation instructions:
+# cp init.d/websockify /etc/init.d/websockify
+# chkconfig --add websockify
+# service websockify start
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+BINDIR=/opt/websockify
+VARDIR=/var/websockify
+WEBSOCKIFY=$BINDIR/run
+WEBSOCKIFY_ADDR=<%= @websockify_address %>
+WEBSOCKIFY_PORT=<%= @websockify_port %>
+PIDFILE=/var/run/websockify.pid
+CONFIG_FILE=$BINDIR/abiquo.cfg
+LOG_FILE=/var/log/websockify
+USER=root
+
+# See how we were called.
+case "$1" in
+  start)
+  [ -x $WEBSOCKIFY ] || exit 1
+  echo -n $"Starting websockify server: "
+  daemon --user "$USER" --pidfile $PIDFILE python "$WEBSOCKIFY" -D "$WEBSOCKIFY_ADDR":"$WEBSOCKIFY_PORT" --token-plugin websockify.abiquo_plugin.AbiquoTokenPlugin --token-source $CONFIG_FILE --log-file="$LOG_FILE"
+  RETVAL=$?
+  echo
+  [ $RETVAL -eq 0 ] && sleep 1 && ps aux | grep [/]opt/websockify/run | awk '{print $2}' > $PIDFILE
+  [ $RETVAL -eq 0 ] && touch /var/lock/subsys/websockify
+  ;;
+  stop)
+  # Stop daemon.
+  echo -n $"Shutting down websockify server: "
+  killproc websockify
+  RETVAL=$?
+  echo
+  [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/websockify
+  ;;
+  status)
+  status websockify
+  RETVAL=$?
+  ;;
+  restart|reload)
+  $0 stop
+  $0 start
+  ;;
+  condrestart)
+  [ -f /var/lock/subsys/websockify ] && restart || :
+  ;;
+  *)
+  echo $"Usage: $0 {start|stop|status|restart}"
+  RETVAL=3
+  ;;
+esac

--- a/templates/rhel/7/conf-websockify.erb
+++ b/templates/rhel/7/conf-websockify.erb
@@ -1,0 +1,7 @@
+WEBSOCKIFY=/opt/websockify/run
+WEBSOCKIFY_PORT=<%= node['abiquo']['websockify']['port'] %>
+WEBSOCKIFY_ADDRESS=<%= node['abiquo']['websockify']['address'] %>
+CERT_FILE=<%= node['abiquo']['websockify']['crt'] %>
+KEY_FILE=<%= node['abiquo']['websockify']['key'] %>
+LOG_FILE=/var/log/websockify.log
+CONFIG_FILE=/opt/websockify/abiquo.cfg

--- a/test/integration/frontend/serverspec/frontend_config_spec.rb
+++ b/test/integration/frontend/serverspec/frontend_config_spec.rb
@@ -53,8 +53,9 @@ describe 'Front-end configuration' do
   end
 
   it 'has websockify service script configured' do
-    expect(file('/etc/init.d/websockify')).to contain('WEBSOCKIFY_PORT=41338')
-    expect(file('/etc/init.d/websockify')).to contain('LOG_FILE=/var/log/websockify')
+    config_file = os[:release].to_i == 6 ? '/etc/init.d/websockify' : '/etc/sysconfig/websockify'
+    expect(file(config_file)).to contain('WEBSOCKIFY_PORT=41338')
+    expect(file(config_file)).to contain('LOG_FILE=/var/log/websockify')
   end
 
   it 'has haproxy service configured' do

--- a/test/integration/frontend/serverspec/frontend_config_spec.rb
+++ b/test/integration/frontend/serverspec/frontend_config_spec.rb
@@ -38,7 +38,7 @@ describe 'Front-end configuration' do
 
   it 'has ssl properly configured' do
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLEngine on')
-    expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLProtocol all -SSLv2 -SSLv3')
+    expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLProtocol All -SSLv2 -SSLv3')
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH')
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLCertificateFile /etc/pki/abiquo/frontend.abiquo.com.crt')
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLCertificateKeyFile /etc/pki/abiquo/frontend.abiquo.com.key')

--- a/test/integration/monolithic/serverspec/monolithic_config_spec.rb
+++ b/test/integration/monolithic/serverspec/monolithic_config_spec.rb
@@ -27,9 +27,16 @@ describe 'Monolithic configuration' do
     end
   end
 
-  it 'has websockify service script configured' do
-    expect(file('/etc/init.d/websockify')).to contain('WEBSOCKIFY_PORT=41338')
-    expect(file('/etc/init.d/websockify')).to contain('LOG_FILE=/var/log/websockify')
+  if os[:release].to_i == 6
+    it 'has websockify service script configured' do
+      expect(file('/etc/init.d/websockify')).to contain('WEBSOCKIFY_PORT=41338')
+      expect(file('/etc/init.d/websockify')).to contain('LOG_FILE=/var/log/websockify')
+    end
+  else
+    it 'has websockify service script configured' do
+      expect(file('/etc/sysconfig/websockify')).to contain('WEBSOCKIFY_PORT=41338')
+      expect(file('/etc/sysconfig/websockify')).to contain('LOG_FILE=/var/log/websockify')
+    end
   end
 
   it 'has the config file for the websockify plugin' do

--- a/test/integration/monolithic/serverspec/monolithic_config_spec.rb
+++ b/test/integration/monolithic/serverspec/monolithic_config_spec.rb
@@ -27,18 +27,12 @@ describe 'Monolithic configuration' do
     end
   end
 
-  if os[:release].to_i == 6
-    it 'has websockify service script configured' do
-      expect(file('/etc/init.d/websockify')).to contain('WEBSOCKIFY_PORT=41338')
-      expect(file('/etc/init.d/websockify')).to contain('LOG_FILE=/var/log/websockify')
-    end
-  else
-    it 'has websockify service script configured' do
-      expect(file('/etc/sysconfig/websockify')).to contain('WEBSOCKIFY_PORT=41338')
-      expect(file('/etc/sysconfig/websockify')).to contain('LOG_FILE=/var/log/websockify')
-    end
+  it 'has websockify service script configured' do
+    config_file = os[:release].to_i == 6 ? '/etc/init.d/websockify' : '/etc/sysconfig/websockify'
+    expect(file(config_file)).to contain('WEBSOCKIFY_PORT=41338')
+    expect(file(config_file)).to contain('LOG_FILE=/var/log/websockify')
   end
-
+  
   it 'has the config file for the websockify plugin' do
     expect(file('/opt/websockify/abiquo.cfg')).to contain('[websockify]')
     expect(file('/opt/websockify/abiquo.cfg')).to contain('ssl_verify = false')

--- a/test/integration/monolithic/serverspec/monolithic_config_spec.rb
+++ b/test/integration/monolithic/serverspec/monolithic_config_spec.rb
@@ -65,7 +65,7 @@ describe 'Monolithic configuration' do
 
   it 'has ssl properly configured' do
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLEngine on')
-    expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLProtocol all -SSLv2 -SSLv3')
+    expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLProtocol All -SSLv2 -SSLv3')
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH')
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLCertificateFile /etc/pki/abiquo/monolithic.abiquo.com.crt')
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLCertificateKeyFile /etc/pki/abiquo/monolithic.abiquo.com.key')

--- a/test/integration/monolithic/serverspec/monolithic_services_spec.rb
+++ b/test/integration/monolithic/serverspec/monolithic_services_spec.rb
@@ -33,10 +33,10 @@ describe 'Monolithic services' do
   end
 
   it 'has redis running' do
-    redisproc = host_inventory['platform_version'] < 7 ? 'redis' : 'redis@'
+    redisproc = os['release'].to_i < 7 ? 'redis' : 'redis@'
     expect(service("#{redisproc}-master")).to be_enabled
     expect(service("#{redisproc}-master")).to be_running
-    expect(service("#{redisproc}-master")).to be_running.under('systemd') if host_inventory['platform_version'] >= 7
+    expect(service("#{redisproc}-master")).to be_running.under('systemd') if os['release'].to_i >= 7
     expect(port(6379)).to be_listening
   end
 

--- a/test/integration/monolithic/serverspec/monolithic_services_spec.rb
+++ b/test/integration/monolithic/serverspec/monolithic_services_spec.rb
@@ -33,8 +33,10 @@ describe 'Monolithic services' do
   end
 
   it 'has redis running' do
-    expect(service('redis-master')).to be_enabled
-    expect(service('redis-master')).to be_running
+    redisproc = host_inventory['platform_version'] < 7 ? 'redis' : 'redis@'
+    expect(service("#{redisproc}-master")).to be_enabled
+    expect(service("#{redisproc}-master")).to be_running
+    expect(service("#{redisproc}-master")).to be_running.under('systemd') if host_inventory['platform_version'] >= 7
     expect(port(6379)).to be_listening
   end
 

--- a/test/integration/monolithic/serverspec/monolithic_services_spec.rb
+++ b/test/integration/monolithic/serverspec/monolithic_services_spec.rb
@@ -34,9 +34,9 @@ describe 'Monolithic services' do
 
   it 'has redis running' do
     redisproc = os[:release].to_i < 7 ? 'redis' : 'redis@'
-    expect(service("#{redisproc}-master")).to be_enabled
-    expect(service("#{redisproc}-master")).to be_running
-    expect(service("#{redisproc}-master")).to be_running.under('systemd') if os['release'].to_i >= 7
+    expect(service("#{redisproc}master")).to be_enabled
+    expect(service("#{redisproc}master")).to be_running
+    expect(service("#{redisproc}master")).to be_running.under('systemd') if os[:release].to_i >= 7
     expect(port(6379)).to be_listening
   end
 

--- a/test/integration/monolithic/serverspec/monolithic_services_spec.rb
+++ b/test/integration/monolithic/serverspec/monolithic_services_spec.rb
@@ -33,7 +33,7 @@ describe 'Monolithic services' do
   end
 
   it 'has redis running' do
-    redisproc = os['release'].to_i < 7 ? 'redis' : 'redis@'
+    redisproc = os[:release].to_i < 7 ? 'redis' : 'redis@'
     expect(service("#{redisproc}-master")).to be_enabled
     expect(service("#{redisproc}-master")).to be_running
     expect(service("#{redisproc}-master")).to be_running.under('systemd') if os['release'].to_i >= 7

--- a/test/integration/remoteservices/serverspec/remoteservices_services_spec.rb
+++ b/test/integration/remoteservices/serverspec/remoteservices_services_spec.rb
@@ -16,8 +16,10 @@ require "#{ENV['BUSSER_ROOT']}/../kitchen/data/serverspec_helper"
 
 describe 'Remote Services services' do
   it 'has redis running' do
-    expect(service('redis-master')).to be_enabled
-    expect(service('redis-master')).to be_running
+    redisproc = os['release'].to_i < 7 ? 'redis' : 'redis@'
+    expect(service("#{redisproc}-master")).to be_enabled
+    expect(service("#{redisproc}-master")).to be_running
+    expect(service("#{redisproc}-master")).to be_running.under('systemd') if os['release'].to_i >= 7
     expect(port(6379)).to be_listening
   end
 

--- a/test/integration/remoteservices/serverspec/remoteservices_services_spec.rb
+++ b/test/integration/remoteservices/serverspec/remoteservices_services_spec.rb
@@ -16,10 +16,10 @@ require "#{ENV['BUSSER_ROOT']}/../kitchen/data/serverspec_helper"
 
 describe 'Remote Services services' do
   it 'has redis running' do
-    redisproc = os['release'].to_i < 7 ? 'redis' : 'redis@'
-    expect(service("#{redisproc}-master")).to be_enabled
-    expect(service("#{redisproc}-master")).to be_running
-    expect(service("#{redisproc}-master")).to be_running.under('systemd') if os['release'].to_i >= 7
+    redisproc = os[:release].to_i < 7 ? 'redis' : 'redis@'
+    expect(service("#{redisproc}master")).to be_enabled
+    expect(service("#{redisproc}master")).to be_running
+    expect(service("#{redisproc}master")).to be_running.under('systemd') if os[:release].to_i >= 7
     expect(port(6379)).to be_listening
   end
 

--- a/test/integration/server/serverspec/server_config_spec.rb
+++ b/test/integration/server/serverspec/server_config_spec.rb
@@ -65,7 +65,7 @@ describe 'Server configuration' do
 
   it 'has ssl properly configured' do
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLEngine on')
-    expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLProtocol all -SSLv2 -SSLv3')
+    expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLProtocol All -SSLv2 -SSLv3')
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH')
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLCertificateFile /etc/pki/abiquo/server.abiquo.com.crt')
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLCertificateKeyFile /etc/pki/abiquo/server.abiquo.com.key')

--- a/test/integration/server/serverspec/server_config_spec.rb
+++ b/test/integration/server/serverspec/server_config_spec.rb
@@ -28,8 +28,9 @@ describe 'Server configuration' do
   end
 
   it 'has websockify service script configured' do
-    expect(file('/etc/init.d/websockify')).to contain('WEBSOCKIFY_PORT=41338')
-    expect(file('/etc/init.d/websockify')).to contain('LOG_FILE=/var/log/websockify')
+    config_file = os[:release].to_i == 6 ? '/etc/init.d/websockify' : '/etc/sysconfig/websockify'
+    expect(file(config_file)).to contain('WEBSOCKIFY_PORT=41338')
+    expect(file(config_file)).to contain('LOG_FILE=/var/log/websockify')
   end
 
   it 'has the config file for the websockify plugin' do

--- a/test/integration/server/serverspec/server_services_spec.rb
+++ b/test/integration/server/serverspec/server_services_spec.rb
@@ -33,8 +33,10 @@ describe 'Server services' do
   end
 
   it 'has redis running' do
-    expect(service('redis-master')).to be_enabled
-    expect(service('redis-master')).to be_running
+    redisproc = os[:release].to_i < 7 ? 'redis' : 'redis@'
+    expect(service("#{redisproc}master")).to be_enabled
+    expect(service("#{redisproc}master")).to be_running
+    expect(service("#{redisproc}master")).to be_running.under('systemd') if os[:release].to_i >= 7
     expect(port(6379)).to be_listening
   end
 

--- a/test/integration/server/serverspec/server_services_spec.rb
+++ b/test/integration/server/serverspec/server_services_spec.rb
@@ -38,11 +38,6 @@ describe 'Server services' do
     expect(port(6379)).to be_listening
   end
 
-  it 'has rpcbind running' do
-    expect(service('rpcbind')).to be_enabled
-    expect(service('rpcbind')).to be_running
-  end
-
   it 'has apache running' do
     expect(service('httpd')).to be_enabled
     expect(service('httpd')).to be_running

--- a/test/integration/ui/serverspec/ui_config_spec.rb
+++ b/test/integration/ui/serverspec/ui_config_spec.rb
@@ -38,7 +38,7 @@ describe 'UI configuration' do
 
   it 'has ssl properly configured' do
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLEngine on')
-    expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLProtocol all -SSLv2 -SSLv3')
+    expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLProtocol All -SSLv2 -SSLv3')
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH')
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLCertificateFile /etc/pki/abiquo/server.abiquo.com.crt')
     expect(file('/etc/httpd/sites-available/abiquo.conf')).to contain('SSLCertificateKeyFile /etc/pki/abiquo/server.abiquo.com.key')

--- a/test/integration/websockify/serverspec/websockify_config_spec.rb
+++ b/test/integration/websockify/serverspec/websockify_config_spec.rb
@@ -28,8 +28,9 @@ describe 'Websockify configuration' do
   end
 
   it 'has websockify service script configured' do
-    expect(file('/etc/init.d/websockify')).to contain('WEBSOCKIFY_PORT=41338')
-    expect(file('/etc/init.d/websockify')).to contain('LOG_FILE=/var/log/websockify')
+    config_file = os[:release].to_i == 6 ? '/etc/init.d/websockify' : '/etc/sysconfig/websockify'
+    expect(file(config_file)).to contain('WEBSOCKIFY_PORT=41338')
+    expect(file(config_file)).to contain('LOG_FILE=/var/log/websockify')
   end
 
   it 'has haproxy service configured' do


### PR DESCRIPTION
Monolithic CentOS 6 tests should be passing again with this.

There are two more tests failing in the C7 profile:

#### Fail to check that redis is running

It tries to check the `redis-master` process, but in C7 it looks like the name is `redis@-master` ? Also noticed there is the official and the Abiquo redis package. Is that correct?

```bash
[root@monolithic-c7 vagrant]# rpm -qa | grep -i redis
redis-3.2.5-1.el7.remi.x86_64
python-redis-2.10.3-1.el7.noarch
abiquo-redis-4.0.0-195.el7.noarch

[root@monolithic-c7 vagrant]# ps aux | grep -i redis
redis    16878  0.1  0.4 142900  4584 ?        Ssl  16:53   0:01 /usr/bin/redis-server 0.0.0.0:6379
root     21615  0.0  0.0 112648   976 pts/0    R+   17:19   0:00 grep --color=auto -i redis

[root@monolithic-c7 vagrant]# systemctl list-units | grep -i redis
  redis@-master.service                                                                    loaded active running   Redis persistent key-value database
  system-redis.slice                                                                       loaded active active    system-redis.slice

[root@monolithic-c7 vagrant]# systemctl is-enabled redis-master
Failed to get unit file state for redis-master.service: No such file or directory
[root@monolithic-c7 vagrant]# systemctl is-enabled redis@-master
enabled
```

#### Fail to check that websockify is listening on 127.0.0.1

Although the config file is properly written, the process seems to be listening in 0.0.0.0. I also noticed that we are manually writing the template to /etc/init.d and we should probably write a proper unit file for C7.

```bash
[root@monolithic-c7 vagrant]# netstat -putan | grep 41
tcp        0      0 0.0.0.0:41337           0.0.0.0:*               LISTEN      20727/haproxy       
tcp        0      0 0.0.0.0:41338           0.0.0.0:*               LISTEN      20692/python        
tcp        0      0 127.0.0.1:41338         127.0.0.1:56060         SYN_RECV    -                   
udp6       0      0 :::41878                :::*                                3462/dhclient       

[root@monolithic-c7 vagrant]# ps aux | grep -i websocki
root     20692  0.0  0.0 243216   868 ?        Ss   17:01   0:00 /bin/python /opt/websockify/run 41338 --token-plugin websockify.abiquo_plugin.AbiquoTokenPlugin --token-source /opt/websockify/abiquo.cfg --cert=$CERT_FILE --key=$KEY_FILE --log-file /var/log/websockify.log
```

@chirauki We can merge this, but it would be good to have a look at the mentioned failing tests and make them pass. Advice is welcome!