### PR TITLE
Fix M credential disappearing from second run

### DIFF
--- a/recipes/install_database.rb
+++ b/recipes/install_database.rb
@@ -61,7 +61,7 @@ ruby_block 'extract-m-user-password' do
     client = Mysql2::Client.new(conn_info.merge(database: 'kinton'))
     query = 'select COMMENTS from DATABASECHANGELOG where ID = "default_user_for_m"'
     result = client.query(query).first['COMMENTS']
-    node.set['abiquo']['properties']['abiquo.m.credential'] = result
+    node.normal['abiquo']['properties']['abiquo.m.credential'] = result
   end
   action :nothing
   not_if { node['abiquo']['properties'].key? 'abiquo.m.credential' }

--- a/spec/install_mariadb_spec.rb
+++ b/spec/install_mariadb_spec.rb
@@ -77,6 +77,15 @@ describe 'abiquo::install_mariadb' do
     expect(resource.privileges).to eq([:all])
   end
 
+  it 'creates the Abiquo DB kinton_accounting user in localhost' do
+    expect(chef_run).to grant_mysql_database_user("kinton_accounting-#{chef_run.node['abiquo']['db']['user']}-localhost")
+    resource = chef_run.find_resource(:mysql_database_user, "kinton_accounting-#{chef_run.node['abiquo']['db']['user']}-localhost")
+    expect(resource.password).to eq(chef_run.node['abiquo']['db']['password'])
+    expect(resource.username).to eq(chef_run.node['abiquo']['db']['user'])
+    expect(resource.host).to eq('localhost')
+    expect(resource.privileges).to eq([:all])
+  end
+
   it 'creates the Watchtower DB user in localhost' do
     expect(chef_run).to grant_mysql_database_user("watchtower-#{chef_run.node['abiquo']['monitoring']['db']['user']}-localhost")
     resource = chef_run.find_resource(:mysql_database_user, "watchtower-#{chef_run.node['abiquo']['monitoring']['db']['user']}-localhost")


### PR DESCRIPTION
The M credential was set in first run, but if chef agent run again
it removed the M credential property.
Also, add a missing test.