### PR TITLE
CentOS 7 to use EV packages

### DIFF
--- a/recipes/install_kvm.rb
+++ b/recipes/install_kvm.rb
@@ -15,28 +15,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# CentOS 7 issue: https://bugs.centos.org/view.php?id=12632&nbn=2
-if node['virtualization']['role'] == 'guest' && node['platform_version'].to_i >= 7
-  yum_repository 'kvm-common' do
-    description 'Backports for the seabios package'
-    baseurl 'http://buildlogs.centos.org/centos/7/virt/x86_64/kvm-common'
-    includepkgs 'seabios,seabios-bin,seavgabios-bin'
-    gpgcheck false
-    action :create
-  end
-
-  package 'yum-plugin-versionlock' do
+if node['platform_version'].to_i >= 7
+  package 'centos-release-qemu-ev' do
     action :install
   end
 
-  yum_package 'seabios' do
-    version '1.7.5-11.el7'
-    action [:lock, :install]
+  package 'qemu-kvm-ev' do
+    action :install
   end
-end
-
-package 'qemu-kvm' do
-  action :install
+else
+  package 'qemu-kvm' do
+    action :install
+  end
 end
 
 %w(aim sosreport-plugins).each do |pkg|

--- a/spec/install_kvm_spec.rb
+++ b/spec/install_kvm_spec.rb
@@ -23,25 +23,20 @@ describe 'abiquo::install_kvm' do
   end
   let(:c6_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5') }
 
-  it 'locks the seabios version on CentOS 7' do
-    expect(chef_run).to create_yum_repository('kvm-common').with(
-      description: 'Backports for the seabios package',
-      baseurl: 'http://buildlogs.centos.org/centos/7/virt/x86_64/kvm-common',
-      includepkgs: 'seabios,seabios-bin,seavgabios-bin',
-      gpgcheck: false
-    )
-    expect(chef_run).to install_package('yum-plugin-versionlock')
-    expect(chef_run).to install_yum_package('seabios').with(version: '1.7.5-11.el7')
-    expect(chef_run).to lock_yum_package('seabios').with(version: '1.7.5-11.el7')
-
-    c6_run.converge(described_recipe)
-    expect(c6_run).to_not install_package('yum-plugin-versionlock')
-    expect(c6_run).to_not create_yum_repository('kvm-common')
-    expect(c6_run).to_not install_yum_package('seabios')
-    expect(c6_run).to_not lock_yum_package('seabios')
+  it 'installs the qemu-ev packages on CentOS 7' do
+    expect(chef_run).to install_package('centos-release-qemu-ev')
+    expect(chef_run).to install_package('qemu-kvm-ev')
+    expect(chef_run).to_not install_package('qemu-kvm')
   end
 
-  %w(qemu-kvm abiquo-aim abiquo-sosreport-plugins).each do |pkg|
+  it 'installs regular qemu packages on CentOS 6' do
+    c6_run.converge(described_recipe)
+    expect(c6_run).to_not install_package('centos-release-qemu-ev')
+    expect(c6_run).to_not install_package('qemu-kvm-ev')
+    expect(c6_run).to install_package('qemu-kvm')
+  end
+
+  %w(abiquo-aim abiquo-sosreport-plugins).each do |pkg|
     it "installs the #{pkg} package" do
       expect(chef_run).to install_package(pkg)
     end

--- a/test/integration/kvm/serverspec/kvm_packages_spec.rb
+++ b/test/integration/kvm/serverspec/kvm_packages_spec.rb
@@ -15,14 +15,6 @@
 require "#{ENV['BUSSER_ROOT']}/../kitchen/data/serverspec_helper"
 
 describe 'KVM packages' do
-  it 'has the qemu package installed' do
-    expect(package('qemu-kvm')).to be_installed
-  end
-
-  it 'has the qemu package installed' do
-    expect(package('qemu-kvm')).to be_installed
-  end
-
   it 'has the qemu binary in place' do
     expect(file('/usr/bin/qemu-system-x86_64')).to exist
   end
@@ -40,9 +32,15 @@ describe 'KVM packages' do
   end
 end
 
+describe 'KVM packages for CentOS 6', if: os[:release].to_i == 6 do
+  it 'has the qemu package installed' do
+    expect(package('qemu-kvm')).to be_installed
+  end
+end
+
 describe 'KVM packages for CentOS 7', if: os[:release].to_i >= 7 do
   it 'has the seabios backport installed' do
-    expect(package('yum-plugin-versionlock')).to be_installed
-    expect(package('seabios')).to be_installed.with_version('1.7.5-11.el7')
+    expect(package('centos-release-qemu-ev')).to be_installed
+    expect(package('qemu-kvm-ev')).to be_installed
   end
 end


### PR DESCRIPTION
`centos-release-qemu-ev` in CentOS 7 provides qemu packages from the
RedHat Enterprise Virtualization dist. This provides significantly
newer qemu versions.