### PR TITLE
Fix upgrade recipe and improve integration tests

### DIFF
--- a/recipes/upgrade.rb
+++ b/recipes/upgrade.rb
@@ -20,6 +20,8 @@ return unless ::File.executable?('/usr/bin/repoquery')
 Chef::Recipe.send(:include, Abiquo::Packages)
 Chef::Recipe.send(:include, Abiquo::Commands)
 
+include_recipe 'abiquo::repository'
+
 unless abiquo_update_available
   log 'No Abiquo updates found.'
   return
@@ -43,8 +45,6 @@ services[node['abiquo']['profile']].each do |svc|
     action :stop
   end
 end
-
-include_recipe 'abiquo::repository'
 
 abiquo_packages.each do |pkg|
   package pkg do

--- a/test/fixtures/common/abiquo_config.rb
+++ b/test/fixtures/common/abiquo_config.rb
@@ -23,4 +23,15 @@ shared_examples 'abiquo::config' do
   it 'has the abiquo properties file' do
     expect(file('/opt/abiquo/config/abiquo.properties')).to exist
   end
+
+  if os[:release].to_i >= 7
+    it 'has the abiquo server environment configured' do
+      expect(file('/etc/sysconfig/abiquo/abiquo-tomcat')).to contain('^CATALINA_HOME=/opt/abiquo/tomcat$')
+      expect(file('/etc/sysconfig/abiquo/abiquo-tomcat')).to contain('^CATALINA_BASE=/opt/abiquo/tomcat$')
+      expect(file('/etc/sysconfig/abiquo/abiquo-tomcat')).to contain('^CATALINA_PID=/opt/abiquo/tomcat/work/catalina.pid$')
+      expect(file('/etc/sysconfig/abiquo/abiquo-tomcat')).to contain('^JAVA_HOME=')
+      expect(file('/etc/sysconfig/abiquo/abiquo-tomcat')).to contain('^JAVA_OPTS=')
+      expect(file('/etc/sysconfig/abiquo/abiquo-tomcat')).to contain('^CATALINA_OPTS=')
+    end
+  end
 end

--- a/test/fixtures/common/v2v_config.rb
+++ b/test/fixtures/common/v2v_config.rb
@@ -16,7 +16,7 @@ require "#{ENV['BUSSER_ROOT']}/../kitchen/data/serverspec_helper"
 
 shared_examples 'v2v::config' do
   it 'has the ec2 api tools configured' do
-    expect(file('/etc/sysconfig/abiquo/ec2-api-tools')).to contain('^export EC2_HOME=')
+    expect(file('/etc/sysconfig/abiquo/ec2-api-tools')).to contain('^EC2_HOME=/opt/aws$')
   end
 
   it 'has the iSCSI initiator name configured' do


### PR DESCRIPTION
* Fixes the upgrade recipe to make sure the yum cache is cleaned before querying the packages that are candidate for upgrade.
* Fixes the integration test that expected the ec2-api-tools environment file to have an `export` keyword.
* Adds checks for the tomcat environment variables.