### PR TITLE
WS listen on 0.0.0.0 by default. Fix #78

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -180,7 +180,6 @@ end
 # Configure Abiquo websockify
 default['abiquo']['websockify']['port'] = 41338
 default['abiquo']['websockify']['address'] = '0.0.0.0'
-default['abiquo']['websockify']['api_url'] = 'https://localhost/api'
 default['abiquo']['websockify']['conf'] = { token_expiration: 10000,
                                             ssl_verify: 'false',
                                             api_user: 'admin',

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -179,7 +179,7 @@ end
 
 # Configure Abiquo websockify
 default['abiquo']['websockify']['port'] = 41338
-default['abiquo']['websockify']['address'] = '127.0.0.1'
+default['abiquo']['websockify']['address'] = '0.0.0.0'
 default['abiquo']['websockify']['api_url'] = 'https://localhost/api'
 default['abiquo']['websockify']['conf'] = { token_expiration: 10000,
                                             ssl_verify: 'false',

--- a/test/fixtures/common/websockify_config.rb
+++ b/test/fixtures/common/websockify_config.rb
@@ -18,6 +18,7 @@ shared_examples 'websockify::config' do
   it 'has websockify service script configured' do
     config_file = os[:release].to_i == 6 ? '/etc/init.d/websockify' : '/etc/sysconfig/websockify'
     expect(file(config_file)).to contain('WEBSOCKIFY_PORT=41338')
+    expect(file(config_file)).to contain('WEBSOCKIFY_ADDR=0.0.0.0')
     expect(file(config_file)).to contain('LOG_FILE=/var/log/websockify')
   end
 

--- a/test/fixtures/common/websockify_config.rb
+++ b/test/fixtures/common/websockify_config.rb
@@ -17,8 +17,9 @@ require "#{ENV['BUSSER_ROOT']}/../kitchen/data/serverspec_helper"
 shared_examples 'websockify::config' do
   it 'has websockify service script configured' do
     config_file = os[:release].to_i == 6 ? '/etc/init.d/websockify' : '/etc/sysconfig/websockify'
+    address_var = os[:release].to_i == 6 ? 'WEBSOCKIFY_ADDR' : 'WEBSOCKIFY_ADDRESS'
     expect(file(config_file)).to contain('WEBSOCKIFY_PORT=41338')
-    expect(file(config_file)).to contain('WEBSOCKIFY_ADDR=0.0.0.0')
+    expect(file(config_file)).to contain("#{address_var}=0.0.0.0")
     expect(file(config_file)).to contain('LOG_FILE=/var/log/websockify')
   end
 

--- a/test/fixtures/common/websockify_services.rb
+++ b/test/fixtures/common/websockify_services.rb
@@ -18,7 +18,7 @@ shared_examples 'websockify::services' do
   it 'has websockify running' do
     expect(service('websockify')).to be_enabled
     expect(service('websockify')).to be_running
-    expect(port(41338)).to be_listening.on('127.0.0.1')
+    expect(port(41338)).to be_listening.on('0.0.0.0')
   end
 
   it 'has the websockify firewall rules configured' do


### PR DESCRIPTION
This should be a better default, but we still can't provide a complete working default config, as we can't preconfigure the Abiquo API url.