### PR TITLE
Properly configure C* and KairosDB services in CentOS 7

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,3 +4,8 @@ metadata
 
 # Used to register a node in RHN and unregister after run for kitchen tests.
 cookbook 'rhn_register', path: 'test/fixtures/cookbooks/rhn_register', group: 'test'
+
+# Contains the fixes needed to the systemd notifications in the C* cookbook. Remove this
+# when https://github.com/michaelklishin/cassandra-chef-cookbook/pull/353 is merged and
+# there is a release of the cookbook.
+cookbook 'cassandra-dse', git: 'https://github.com/nacx/cassandra-chef-cookbook.git', branch: 'systemd-fixes'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+## 0.11.2
+
+* Configure the RabbitMQ node name so it is possible to change the hostname without
+  causing issues in the RabbitMQ configuration.
+* Replaced the RabbitMQ 'host' and 'port' propertues by the 'addresses' property to
+  allow configuring access to a cluster of brokers.
+* Upgraded cassandra-dse cookbook to version 4.4.0 to support systemd.
+* Configure the KairosDB service as a systemd unit in CentOS 7.
+
 ## 0.11.1
 
 * Updated metadata and added files to meet the Chef Supermarket quality metrics.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -126,8 +126,6 @@ default['abiquo']['aim']['neutron']['admin_password'] = 'xabiquo'
 
 # Configure monitoring node
 default['abiquo']['monitoring']['cassandra']['cluster_name'] = 'abiquo'
-default['abiquo']['monitoring']['kairosdb']['version'] = '0.9.4'
-default['abiquo']['monitoring']['kairosdb']['release'] = '6'
 default['abiquo']['monitoring']['kairosdb']['host'] = 'localhost'
 default['abiquo']['monitoring']['kairosdb']['port'] = 8080
 default['abiquo']['monitoring']['rabbitmq']['addresses'] = ['localhost:5672']
@@ -150,6 +148,7 @@ default['java']['jdk_version'] = 8
 
 # Override Cassandra default configuration to make sure it is always running properly
 default['cassandra']['notify_restart'] = true
+default['cassandra']['use_systemd'] = true if node['platform_version'].to_i >= 7
 
 # Default properties
 default['abiquo']['properties']['abiquo.datacenter.id'] = node['hostname']

--- a/metadata.rb
+++ b/metadata.rb
@@ -34,6 +34,7 @@ recipe 'abiquo::kvm_neutron', 'Configures a KVM hypervisor to use OpenStack Neut
 recipe 'abiquo::upgrade', 'Upgrades an Abiquo platform'
 recipe 'abiquo::install_database', 'Creates the Abiquo database'
 recipe 'abiquo::install_ext_services', 'Installs Abiquo supporting services (MariaDB, RabbitMQ, Redis)'
+recipe 'abiquo::install_kairosdb', 'Installs KairosDB'
 recipe 'abiquo::certificate', 'Installs a custom SSL certificate in the Apache'
 recipe 'abiquo::service', 'Manages Abiquo tomcat service'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -41,7 +41,7 @@ supports 'centos', '>= 6.7'
 supports 'redhat', '>= 6.7'
 
 depends 'apache2', '~> 3.1.0'
-depends 'cassandra-dse', '~> 4.1.0'
+depends 'cassandra-dse', '~> 4.4.0'
 depends 'iptables', '~> 2.0.1'
 depends 'java', '~> 1.46.0'
 depends 'java-management', '~> 1.0.3'

--- a/recipes/install_kairosdb.rb
+++ b/recipes/install_kairosdb.rb
@@ -1,0 +1,79 @@
+# Cookbook Name:: abiquo
+# Recipe:: install_kairosdb
+#
+# Copyright 2014, Abiquo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package 'kairosdb' do
+  action :install
+  # We want the service to be stopped immediately after the rpm package starts it, if we are going
+  # to replace its config file by a systemd unit. Otherwise we won't be able to properly manage it.
+  notifies :stop, 'service[kairosdb]', :immediately if node['platform_version'].to_i == 7
+  notifies :disable, 'service[kairosdb]', :immediately if node['platform_version'].to_i == 7
+end
+
+service 'kairosdb' do
+  action :enable
+end
+
+if node['platform_version'].to_i == 7
+  # Configure a systemd script if we are in CentOS 7
+  file '/etc/init.d/kairosdb' do
+    action :delete
+  end
+
+  group 'kairosdb' do
+    system true
+    action :create
+  end
+
+  user 'kairosdb' do
+    system true
+    gid 'kairosdb'
+    shell '/bin/false'
+    action :create
+  end
+
+  directory '/var/run/kairosdb' do
+    owner 'kairosdb'
+    group 'kairosdb'
+    mode '0755'
+    action :create
+  end
+
+  execute 'chown-kairosdb' do
+    command 'chown -R kairosdb:kairosdb /opt/kairosdb'
+    action :run
+  end
+
+  systemd_unit 'kairosdb.service' do
+    content <<-EOU.gsub(/^\s+/, '')
+    [Unit]
+    Description=KairosDB
+
+    [Service]
+    Type=forking
+    User=kairosdb
+    Environment=KAIROS_PID_FILE=/var/run/kairosdb/kairosdb.pid
+    PIDFile=/var/run/kairosdb/kairosdb.pid
+    ExecStart=/opt/kairosdb/bin/kairosdb.sh start
+    ExecStop=/opt/kairosdb/bin/kairosdb.sh stop
+
+    [Install]
+    WantedBy=multi-user.target
+    EOU
+    action [:create, :enable]
+    notifies :restart, 'service[kairosdb]'
+  end
+end

--- a/recipes/install_monitoring.rb
+++ b/recipes/install_monitoring.rb
@@ -33,45 +33,7 @@ node.set['cassandra']['config']['cluster_name'] = node['abiquo']['monitoring']['
 node.set['cassandra']['install_java'] = false # The Abiquo jdk package is installed instead
 include_recipe 'cassandra-dse'
 
-service 'kairosdb' do
-  action :nothing
-end
-
-package 'kairosdb' do
-  action :install
-  # We want the service to be stopped immediately after the rpm package starts it, if we are going
-  # to replace its config file by a systemd unit. Otherwise we won't be able to properly manage it.
-  notifies :stop, 'service[kairosdb]', :immediately if node['platform_version'].to_i == 7
-end
-
-# Configure a systemd script if we are in CentOS 7
-file '/etc/init.d/kairosdb' do
-  action :delete
-  only_if { node['platform_version'].to_i == 7 }
-end
-
-systemd_unit 'kairosdb.service' do
-  content <<-EOU.gsub(/^\s+/, '')
-	[Unit]
-	Description=KairosDB is a fast distributed scalable time series database written on top of Cassandra.
-	Requires=cassandra.service
-	After=cassandra.service
-
-	[Service]
-	Type=forking
-	User=root
-	PIDFile=/var/run/kairosdb.pid
-	ExecStart=/opt/kairosdb/bin/kairosdb.sh start
-	ExecStop=/opt/kairosdb/bin/kairosdb.sh stop
-
-	[Install]
-	WantedBy=multi-user.target
-  EOU
-  action [:create, :enable]
-  notifies :restart, 'service[kairosdb]'
-  only_if { node['platform_version'].to_i == 7 }
-end
-
+include_recipe 'abiquo::install_kairosdb'
 include_recipe 'abiquo::install_ext_services' if node['abiquo']['install_ext_services']
 
 %w(delorean emmett).each do |pkg|

--- a/recipes/setup_monitoring.rb
+++ b/recipes/setup_monitoring.rb
@@ -15,10 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-service 'kairosdb' do
-  action :nothing
-end
-
 template '/opt/kairosdb/conf/kairosdb.properties' do
   source 'kairosdb.properties.erb'
   owner 'root'

--- a/spec/install_kairosdb_spec.rb
+++ b/spec/install_kairosdb_spec.rb
@@ -1,0 +1,81 @@
+# Copyright 2014, Abiquo
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'abiquo::install_kairosdb' do
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  let(:c6_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5').converge(described_recipe) }
+
+  it 'enables the kairosdb service' do
+    expect(chef_run).to enable_service('kairosdb')
+  end
+
+  it 'installs the kairosdb package' do
+    expect(chef_run).to install_package('kairosdb')
+    resource = chef_run.package('kairosdb')
+    expect(resource).to notify('service[kairosdb]').to(:stop).immediately
+    expect(resource).to notify('service[kairosdb]').to(:disable).immediately
+  end
+
+  it 'does not stop the kairos service after installing in CentOS 6' do
+    resource = c6_run.package('kairosdb')
+    expect(resource).to_not notify('service[kairosdb]').to(:stop)
+    expect(resource).to_not notify('service[kairosdb]').to(:disable)
+  end
+
+  it 'configures the kairos user in CentOS 7' do
+    expect(chef_run).to create_user('kairosdb').with(
+      system: true,
+      gid: 'kairosdb',
+      shell: '/bin/false'
+    )
+  end
+
+  it 'configures the kairos group in CentOS 7' do
+    expect(chef_run).to create_group('kairosdb').with(system: true)
+  end
+
+  it 'configures the kairos permissions in CentOS 7' do
+    expect(chef_run).to create_directory('/var/run/kairosdb').with(
+      owner: 'kairosdb',
+      group: 'kairosdb',
+      mode: '0755'
+    )
+    expect(chef_run).to run_execute('chown-kairosdb').with(
+      command: 'chown -R kairosdb:kairosdb /opt/kairosdb'
+    )
+  end
+
+  it 'does not configure the kairos user and permissions in CentOS 6' do
+    expect(c6_run).to_not create_user('kairosdb')
+    expect(c6_run).to_not create_group('kairosdb')
+    expect(c6_run).to_not create_directory('/var/run/kairosdb')
+    expect(c6_run).to_not run_execute('chown-kairosdb')
+  end
+
+  it 'installs the systemd service unit in CentOS 7' do
+    expect(chef_run).to delete_file('/etc/init.d/kairosdb')
+    expect(chef_run).to create_systemd_unit('kairosdb.service')
+    expect(chef_run).to create_systemd_unit('kairosdb.service')
+    resource = chef_run.systemd_unit('kairosdb.service')
+    expect(resource).to notify('service[kairosdb]').to(:restart).delayed
+  end
+
+  it 'does not install the systemd service unit in CentOS 6' do
+    expect(c6_run).to_not delete_file('/etc/init.d/kairosdb')
+    expect(c6_run).to_not create_systemd_unit('kairosdb.service')
+    expect(c6_run).to_not enable_systemd_unit('kairosdb.service')
+  end
+end

--- a/spec/install_monitoring_spec.rb
+++ b/spec/install_monitoring_spec.rb
@@ -22,11 +22,6 @@ describe 'abiquo::install_monitoring' do
       node.set['abiquo']['profile'] = 'monitoring'
     end.converge(described_recipe)
   end
-  let(:c6_run) do
-    ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5') do |node|
-      node.set['abiquo']['profile'] = 'monitoring'
-    end.converge(described_recipe)
-  end
 
   before do
     stub_queries
@@ -47,40 +42,12 @@ describe 'abiquo::install_monitoring' do
     expect(chef_run).to include_recipe('cassandra-dse')
   end
 
+  it 'includes the kairosdb recipe' do
+    expect(chef_run).to include_recipe('abiquo::install_kairosdb')
+  end
+
   it 'includes the install_ext_services recipe by default' do
     expect(chef_run).to include_recipe('abiquo::install_ext_services')
-  end
-
-  it 'declares the kairosdb service' do
-    resource = chef_run.service('kairosdb')
-    expect(resource).to do_nothing
-  end
-
-  it 'installs the kairosdb package' do
-    expect(chef_run).to install_package('kairosdb')
-    resource = chef_run.package('kairosdb')
-    expect(resource).to notify('service[kairosdb]').to(:stop).immediately
-  end
-
-  it 'does not stop the kairos service after installing in CentOS 6' do
-    c6_run.converge(described_recipe)
-    resource = c6_run.package('kairosdb')
-    expect(resource).to_not notify('service[kairosdb]').to(:stop)
-  end
-
-  it 'installs the systemd service unit in CentOS 7' do
-    expect(chef_run).to delete_file('/etc/init.d/kairosdb')
-    expect(chef_run).to create_systemd_unit('kairosdb.service')
-    expect(chef_run).to create_systemd_unit('kairosdb.service')
-    resource = chef_run.systemd_unit('kairosdb.service')
-    expect(resource).to notify('service[kairosdb]').to(:restart).delayed
-  end
-
-  it 'does not install the systemd service unit in CentOS 6' do
-    c6_run.converge(described_recipe)
-    expect(c6_run).to_not delete_file('/etc/init.d/kairosdb')
-    expect(c6_run).to_not create_systemd_unit('kairosdb.service')
-    expect(c6_run).to_not enable_systemd_unit('kairosdb.service')
   end
 
   it 'does not include install_ext_services recipe if not configured' do

--- a/spec/setup_monitoring_spec.rb
+++ b/spec/setup_monitoring_spec.rb
@@ -18,12 +18,7 @@ describe 'abiquo::setup_monitoring' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new do |node|
       node.set['cassandra']['config']['cluster_name'] = 'abiquo'
-    end.converge('cassandra-dse', described_recipe)
-  end
-
-  it 'declares the kairosdb service' do
-    resource = chef_run.service('kairosdb')
-    expect(resource).to do_nothing
+    end.converge('cassandra-dse', 'abiquo::service', 'abiquo::install_monitoring', described_recipe)
   end
 
   it 'renders the kairosdb configuration file' do

--- a/test/integration/monitoring/serverspec/monitoring_config_spec.rb
+++ b/test/integration/monitoring/serverspec/monitoring_config_spec.rb
@@ -24,7 +24,7 @@ describe 'Monitoring configuration' do
   end
 
   it 'java 8 is the default one' do
-    expect(command('java -version').stderr).to contain('java version "1.8')
+    expect(command('java -version').stderr).to contain('version "1.8')
   end
 
   it 'has delorean properly configured' do

--- a/test/integration/monitoring/serverspec/monitoring_config_spec.rb
+++ b/test/integration/monitoring/serverspec/monitoring_config_spec.rb
@@ -43,3 +43,16 @@ describe 'Monitoring configuration' do
     expect(file('/etc/abiquo/watchtower/emmett.conf')).to contain('addresses = ["localhost:5672"]')
   end
 end
+
+describe 'Monitoring configuration for CentOS 7', if: os[:release].to_i >= 7 do
+  it 'has the kairosdb user configured' do
+    expect(group('kairosdb')).to exist
+    expect(user('kairosdb')).to belong_to_group('kairosdb')
+  end
+
+  it 'has the kairosdb permissions configured' do
+    expect(file('/var/run/kairosdb')).to be_directory
+    expect(file('/var/run/kairosdb')).to be_owned_by('kairosdb')
+    expect(file('/opt/kairosdb')).to be_owned_by('kairosdb')
+  end
+end

--- a/test/integration/monitoring/serverspec/monitoring_services_spec.rb
+++ b/test/integration/monitoring/serverspec/monitoring_services_spec.rb
@@ -51,3 +51,9 @@ describe 'Monitoring services' do
     expect(port(36638)).to be_listening
   end
 end
+
+describe 'Monitoring services for CentOS 7', if: os[:release].to_i >= 7 do
+  it 'has the kairosdb service running as the kairosdb user' do
+    expect(command('ps h -u kairosdb -o cmd').stdout).to match(/.*org\.kairosdb\.core\.Main.*/)
+  end
+end

--- a/test/integration/monitoring/serverspec/monitoring_services_spec.rb
+++ b/test/integration/monitoring/serverspec/monitoring_services_spec.rb
@@ -27,6 +27,7 @@ describe 'Monitoring services' do
   it 'has the cassandra service running' do
     expect(service('cassandra')).to be_enabled
     expect(service('cassandra')).to be_running
+    expect(service('cassandra')).to be_running.under('systemd') if os[:release].to_i >= 7
     expect(port(9160)).to be_listening
     expect(port(7000)).to be_listening
   end
@@ -34,6 +35,7 @@ describe 'Monitoring services' do
   it 'has the kairosdb service running' do
     expect(service('kairosdb')).to be_enabled
     expect(service('kairosdb')).to be_running
+    expect(service('kairosdb')).to be_running.under('systemd') if os[:release].to_i >= 7
     expect(port(8080)).to be_listening
   end
 


### PR DESCRIPTION
Depends on a change to the C* cookbook. Once https://github.com/michaelklishin/cassandra-chef-cookbook/pull/353 is merged and released we'll need to remove the reference to the cookbook fork in the Berksfile.

Once there is a better package for KairosDB we should also remove the custom systemd unit file from the monitoring recipes.

Fixes #68.