### PR TITLE
Filter packages by vendor to better identify Abiquo packages

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -46,8 +46,8 @@ module Abiquo
     include Chef::Mixin::ShellOut
 
     def abiquo_packages
-      pkgs_cmd = shell_out!('repoquery --installed \'abiquo-*\' --qf \'%{name}\'')
-      pkgs_cmd.stdout.split
+      pkgs_cmd = shell_out!('repoquery --installed -a --qf \'%{name}@%{vendor}\'')
+      pkgs_cmd.stdout.split(/\n/).select { |n| n.split(/@/)[1] =~ /^Abiquo/ }.map { |n| n.split(/@/)[0] }
     end
 
     def abiquo_update_available

--- a/spec/support/packages.rb
+++ b/spec/support/packages.rb
@@ -19,9 +19,9 @@ def stub_package_commands(packages)
   lang = { 'LC_ALL' => Chef::Config[:internal_locale], 'LANGUAGE' => Chef::Config[:internal_locale], 'LANG' => Chef::Config[:internal_locale] }
   stub_const('ENV', lang)
 
-  names_result = packages.join("\n")
+  names_result = packages.map { |p| p + '@Abiquo Inc.' }.join("\n")
   names_result << "\n"
-  allow(Mixlib::ShellOut).to receive(:new).with('repoquery --installed \'abiquo-*\' --qf \'%{name}\'', environment: lang).and_return(abiquo)
+  allow(Mixlib::ShellOut).to receive(:new).with('repoquery --installed -a --qf \'%{name}@%{vendor}\'', environment: lang).and_return(abiquo)
   allow(abiquo).to receive(:run_command).and_return(nil)
   allow(abiquo).to receive(:live_stream).and_return(nil)
   allow(abiquo).to receive(:live_stream=).and_return(nil)


### PR DESCRIPTION
This way the upgrade recipe will take into account Abiquo packages which name is not prefixed with `abiquo-`. This is related to (but does not compete) #74.