### PR TITLE
Fix KairosDB cache permissions

### DIFF
--- a/recipes/install_kairosdb.rb
+++ b/recipes/install_kairosdb.rb
@@ -45,7 +45,7 @@ if node['platform_version'].to_i == 7
     action :create
   end
 
-  directory '/var/run/kairosdb' do
+  directory '/opt/kairosdb/run' do
     owner 'kairosdb'
     group 'kairosdb'
     mode '0755'
@@ -57,6 +57,12 @@ if node['platform_version'].to_i == 7
     action :run
   end
 
+  # Workaround for: https://github.com/kairosdb/kairosdb/issues/152
+  execute 'chown-kairosdb-cache' do
+    command 'chown -R kairosdb:kairosdb /tmp/kairos_cache'
+    action :run
+  end
+
   systemd_unit 'kairosdb.service' do
     content <<-EOU.gsub(/^\s+/, '')
     [Unit]
@@ -65,8 +71,8 @@ if node['platform_version'].to_i == 7
     [Service]
     Type=forking
     User=kairosdb
-    Environment=KAIROS_PID_FILE=/var/run/kairosdb/kairosdb.pid
-    PIDFile=/var/run/kairosdb/kairosdb.pid
+    Environment=KAIROS_PID_FILE=/opt/kairosdb/run/kairosdb.pid
+    PIDFile=/opt/kairosdb/run/kairosdb.pid
     ExecStart=/opt/kairosdb/bin/kairosdb.sh start
     ExecStop=/opt/kairosdb/bin/kairosdb.sh stop
 

--- a/spec/install_kairosdb_spec.rb
+++ b/spec/install_kairosdb_spec.rb
@@ -48,7 +48,7 @@ describe 'abiquo::install_kairosdb' do
   end
 
   it 'configures the kairos permissions in CentOS 7' do
-    expect(chef_run).to create_directory('/var/run/kairosdb').with(
+    expect(chef_run).to create_directory('/opt/kairosdb/run').with(
       owner: 'kairosdb',
       group: 'kairosdb',
       mode: '0755'
@@ -56,13 +56,17 @@ describe 'abiquo::install_kairosdb' do
     expect(chef_run).to run_execute('chown-kairosdb').with(
       command: 'chown -R kairosdb:kairosdb /opt/kairosdb'
     )
+    expect(chef_run).to run_execute('chown-kairosdb-cache').with(
+      command: 'chown -R kairosdb:kairosdb /tmp/kairos_cache'
+    )
   end
 
   it 'does not configure the kairos user and permissions in CentOS 6' do
     expect(c6_run).to_not create_user('kairosdb')
     expect(c6_run).to_not create_group('kairosdb')
-    expect(c6_run).to_not create_directory('/var/run/kairosdb')
+    expect(c6_run).to_not create_directory('/opt/kairosdb/run')
     expect(c6_run).to_not run_execute('chown-kairosdb')
+    expect(c6_run).to_not run_execute('chown-kairosdb-cache')
   end
 
   it 'installs the systemd service unit in CentOS 7' do

--- a/test/integration/monitoring/serverspec/monitoring_config_spec.rb
+++ b/test/integration/monitoring/serverspec/monitoring_config_spec.rb
@@ -51,8 +51,7 @@ describe 'Monitoring configuration for CentOS 7', if: os[:release].to_i >= 7 do
   end
 
   it 'has the kairosdb permissions configured' do
-    expect(file('/var/run/kairosdb')).to be_directory
-    expect(file('/var/run/kairosdb')).to be_owned_by('kairosdb')
     expect(file('/opt/kairosdb')).to be_owned_by('kairosdb')
+    expect(file('/tmp/kairos_cache')).to be_owned_by('kairosdb')
   end
 end


### PR DESCRIPTION
Configure the permissions of the KairosDB cache directory to workaround https://github.com/kairosdb/kairosdb/issues/152 and move the PID directory to `/opt/kairosdb` since `/var/run` is usually mounted as `tmpfs`.