### PR TITLE
Fix default config for WS

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -179,10 +179,7 @@ end
 # Configure Abiquo websockify
 default['abiquo']['websockify']['port'] = 41338
 default['abiquo']['websockify']['address'] = '0.0.0.0'
-default['abiquo']['websockify']['conf'] = { token_expiration: 10000,
-                                            ssl_verify: 'false',
-                                            api_user: 'admin',
-                                            api_pass: 'xabiquo' }
+default['abiquo']['websockify']['conf'] = nil
 default['abiquo']['websockify']['crt'] = node['abiquo']['certificate']['file']
 default['abiquo']['websockify']['key'] = node['abiquo']['certificate']['key_file']
 default['haproxy']['enable_default_http'] = false

--- a/recipes/setup_websockify.rb
+++ b/recipes/setup_websockify.rb
@@ -35,11 +35,17 @@ else
   end
 end
 
+default_config = { token_expiration: 10000,
+                   ssl_verify: 'false',
+                   api_user: 'admin',
+                   api_pass: 'xabiquo' }
+ws_config = node['abiquo']['websockify']['conf'].nil? ? default_config : node['abiquo']['websockify']['conf']
+
 template '/opt/websockify/abiquo.cfg' do
   source 'ws_abiquo.cfg.erb'
   owner 'root'
   group 'root'
-  variables(wsvars: node['abiquo']['websockify']['conf'])
+  variables(wsvars: ws_config)
   action :create
   notifies :restart, 'service[websockify]'
 end

--- a/spec/install_monolithic_spec.rb
+++ b/spec/install_monolithic_spec.rb
@@ -25,11 +25,7 @@ describe 'abiquo::install_monolithic' do
   let(:cn) { 'fauxhai.local' }
 
   before do
-    stub_check_db_pass_command('root', '')
-    stub_certificate_files('/etc/pki/abiquo/fauxhai.local.crt', '/etc/pki/abiquo/fauxhai.local.key')
     stub_command('/usr/sbin/httpd -t').and_return(true)
-    stub_command("/usr/bin/test -f /etc/pki/abiquo/#{cn}.crt").and_return(true)
-    stub_command('rabbitmqctl list_users | egrep -q \'^abiquo.*\'').and_return(false)
   end
 
   %w(server remoteservices v2v).each do |recipe|

--- a/spec/install_remoteservices_spec.rb
+++ b/spec/install_remoteservices_spec.rb
@@ -22,11 +22,6 @@ describe 'abiquo::install_remoteservices' do
     end.converge(described_recipe, 'abiquo::service')
   end
 
-  before do
-    stub_command('rabbitmqctl list_users | egrep -q \'^abiquo.*\'').and_return(false)
-    stub_check_db_pass_command('root', '')
-  end
-
   it 'includes needed recipes' do
     %w(java::oracle_jce abiquo::install_ext_services abiquo::certificate).each do |recipe|
       expect(chef_run).to include_recipe(recipe)

--- a/spec/install_server_spec.rb
+++ b/spec/install_server_spec.rb
@@ -26,11 +26,7 @@ describe 'abiquo::install_server' do
 
   before do
     stub_certificate_files('/etc/pki/abiquo/fauxhai.local.crt', '/etc/pki/abiquo/fauxhai.local.key')
-    stub_check_db_pass_command('root', '')
     stub_command('/usr/sbin/httpd -t').and_return(true)
-    stub_command("/usr/bin/test -f /etc/pki/abiquo/#{cn}.crt").and_return(false)
-    stub_command("rabbitmqctl list_users | egrep -q '^abiquo.*'").and_return(false)
-    stub_certificate_files('/etc/pki/abiquo/fauxhai.local.crt', '/etc/pki/abiquo/fauxhai.local.key')
   end
 
   it 'installs the Apache recipes' do

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -18,10 +18,6 @@ require_relative 'support/commands'
 describe 'abiquo::service' do
   let(:chef_run) { ChefSpec::SoloRunner.new }
 
-  before do
-    stub_check_db_pass_command('root', '')
-  end
-
   it 'defines the abiquo-tomcat service' do
     chef_run.converge(described_recipe)
     expect(chef_run).to enable_service('abiquo-tomcat')

--- a/spec/support/commands.rb
+++ b/spec/support/commands.rb
@@ -16,11 +16,8 @@ def stub_check_db_pass_command(user, pass, new_pass = '')
   dbpass = double('dbpass')
   passhash = double('passhash')
 
-  lang = { 'LC_ALL' => Chef::Config[:internal_locale], 'LANGUAGE' => Chef::Config[:internal_locale], 'LANG' => Chef::Config[:internal_locale] }
-  stub_const('ENV', lang)
-
   current_pass_query = "select Password from mysql.user where User = \"#{user}\" and Host = \"%\""
-  allow(Mixlib::ShellOut).to receive(:new).with("/usr/bin/mysql -B --skip-column-names -e '#{current_pass_query}'", environment: lang).and_return(dbpass)
+  allow(Chef::Mixin::ShellOut).to receive(:new).with("/usr/bin/mysql -B --skip-column-names -e '#{current_pass_query}'", any_args).and_return(dbpass)
   allow(dbpass).to receive(:run_command).and_return(nil)
   allow(dbpass).to receive(:live_stream).and_return(nil)
   allow(dbpass).to receive(:live_stream=).and_return(nil)
@@ -28,7 +25,7 @@ def stub_check_db_pass_command(user, pass, new_pass = '')
   allow(dbpass).to receive(:stdout).and_return(pass)
 
   new_pass_query = "select PASSWORD(\"#{new_pass}\")"
-  allow(Mixlib::ShellOut).to receive(:new).with("/usr/bin/mysql -B --skip-column-names -e '#{new_pass_query}'", environment: lang).and_return(passhash)
+  allow(Mixlib::ShellOut).to receive(:new).with("/usr/bin/mysql -B --skip-column-names -e '#{new_pass_query}'", any_args).and_return(passhash)
   allow(passhash).to receive(:run_command).and_return(nil)
   allow(passhash).to receive(:live_stream).and_return(nil)
   allow(passhash).to receive(:live_stream=).and_return(nil)

--- a/spec/support/packages.rb
+++ b/spec/support/packages.rb
@@ -13,15 +13,14 @@
 # limitations under the License.
 
 def stub_package_commands(packages)
+  allow(Mixlib::ShellOut).to receive(:new).with(any_args).and_call_original
+
   abiquo = double('abiquo')
   installed = double('installed')
 
-  lang = { 'LC_ALL' => Chef::Config[:internal_locale], 'LANGUAGE' => Chef::Config[:internal_locale], 'LANG' => Chef::Config[:internal_locale] }
-  stub_const('ENV', lang)
-
   names_result = packages.map { |p| p + '@Abiquo Inc.' }.join("\n")
   names_result << "\n"
-  allow(Mixlib::ShellOut).to receive(:new).with('repoquery --installed -a --qf \'%{name}@%{vendor}\'', environment: lang).and_return(abiquo)
+  allow(Mixlib::ShellOut).to receive(:new).with('repoquery --installed -a --qf \'%{name}@%{vendor}\'', any_args).and_return(abiquo)
   allow(abiquo).to receive(:run_command).and_return(nil)
   allow(abiquo).to receive(:live_stream).and_return(nil)
   allow(abiquo).to receive(:live_stream=).and_return(nil)
@@ -31,7 +30,7 @@ def stub_package_commands(packages)
   names = packages.join(' ')
   current = packages.map { |p| p + '-0:3.6.1-85.el6.noarch' }.join("\n")
   current << "\n"
-  allow(Mixlib::ShellOut).to receive(:new).with("repoquery --installed #{names}", environment: lang).and_return(installed)
+  allow(Mixlib::ShellOut).to receive(:new).with("repoquery --installed #{names}", any_args).and_return(installed)
   allow(installed).to receive(:run_command).and_return(nil)
   allow(installed).to receive(:live_stream).and_return(nil)
   allow(installed).to receive(:live_stream=).and_return(nil)
@@ -42,14 +41,12 @@ def stub_package_commands(packages)
 end
 
 def stub_available_packages(packages, version)
-  lang = { 'LC_ALL' => Chef::Config[:internal_locale], 'LANGUAGE' => Chef::Config[:internal_locale], 'LANG' => Chef::Config[:internal_locale] }
-
   available = double('available')
   names = packages.join(' ')
   upstream = packages.map { |p| p + version }.join("\n")
   upstream << "\n"
 
-  allow(Mixlib::ShellOut).to receive(:new).with("repoquery #{names}", environment: lang).and_return(available)
+  allow(Mixlib::ShellOut).to receive(:new).with("repoquery #{names}", any_args).and_return(available)
   allow(available).to receive(:run_command).and_return(nil)
   allow(available).to receive(:live_stream).and_return(nil)
   allow(available).to receive(:live_stream=).and_return(nil)

--- a/spec/support/stubs.rb
+++ b/spec/support/stubs.rb
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 def stub_certificate_files(cert, _key)
-  cert = double('cert')
-  allow(::File).to receive(:open).with(anything).and_return(cert)
-  allow(cert).to receive(:read).and_return('randomstring')
+  crt = double('cert')
+  allow(::File).to receive(:open).with(cert, any_args).and_return(crt)
+  allow(::File).to receive(:open).with(any_args).and_call_original
+  allow(crt).to receive(:read).and_return('randomstring')
 end


### PR DESCRIPTION
The default attrib value sets the user and pass. If using OAuth tokens
for WS, the default user and pass are still written to the config
file. Since the plugin checks first on the presence of user and pass
the OAuth tokens are never used and no valid auth can be done against
API. This commit waits to set the default config to the setup recipe
so the default config is only written if no config is provided.